### PR TITLE
Support multiple datasources in sequelization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,4 +52,19 @@ export { type ISQLFlavor } from "./Flavor";
 export type { ExpressionRawValue, ExpressionValue } from "./Expression";
 
 // Target exports
-export { SQLTarget } from "./targets";
+export {
+  SQLTarget,
+  DynamoDBPartiQLTarget,
+  DynamoDBNativeTarget,
+} from "./targets";
+
+export type {
+  DynamoDBNativeTargetOptions,
+  AttributeValue,
+  DynamoDBQueryInput,
+  DynamoDBScanInput,
+  DynamoDBPutItemInput,
+  DynamoDBUpdateItemInput,
+  DynamoDBDeleteItemInput,
+  DynamoDBBatchWriteItemInput,
+} from "./targets";

--- a/src/targets/README.md
+++ b/src/targets/README.md
@@ -1,0 +1,431 @@
+# Query Targets
+
+This directory contains implementations of `IQueryTarget` for compiling ts-query queries to different backend formats.
+
+## Available Targets
+
+### SQLTarget
+
+Wraps existing SQL flavors (MySQL, SQLite, AWS Timestream) for backward compatibility.
+
+```typescript
+import { Q, Cond, SQLTarget } from 'ts-query';
+
+const target = new SQLTarget(Q.flavors.mysql);
+const query = Q.select().from('users').where(Cond.equal('id', 1));
+
+console.log(query.compile(target));
+// → "SELECT * FROM `users` WHERE `id` = 1"
+```
+
+### DynamoDBPartiQLTarget
+
+Compiles queries to PartiQL statements for DynamoDB's `ExecuteStatement` API.
+
+```typescript
+import { Q, Cond, DynamoDBPartiQLTarget } from 'ts-query';
+
+const target = new DynamoDBPartiQLTarget();
+const query = Q.select()
+  .from('Users')
+  .where(Cond.equal('pk', 'USER#123'))
+  .where(Cond.like('sk', 'ORDER#%'));
+
+console.log(query.compile(target));
+// → "SELECT * FROM Users WHERE pk = 'USER#123' AND begins_with(sk, 'ORDER#')"
+```
+
+### DynamoDBNativeTarget
+
+Compiles queries to DynamoDB API input objects for Query, Scan, PutItem, UpdateItem, DeleteItem.
+
+```typescript
+import { Q, Cond, DynamoDBNativeTarget } from 'ts-query';
+import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+
+const target = new DynamoDBNativeTarget({
+  partitionKey: 'pk',
+  sortKey: 'sk',
+  indexName: 'GSI1',
+});
+
+const query = Q.select()
+  .from('Users')
+  .addField('name')
+  .addField('email')
+  .where(Cond.equal('pk', 'USER#123'))
+  .limit(10);
+
+const input = query.compile(target);
+// → DynamoDBQueryInput with KeyConditionExpression, ProjectionExpression, etc.
+
+const client = new DynamoDBClient({});
+const result = await client.send(new QueryCommand(input));
+```
+
+---
+
+## Creating Custom Targets
+
+You can create custom targets by implementing the `IQueryTarget<TOutput>` interface.
+
+### Interface
+
+```typescript
+interface IQueryTarget<TOutput> {
+  compileSelect(query: SelectQuery): TOutput;
+  compileInsert(mutation: InsertMutation): TOutput;
+  compileUpdate(mutation: UpdateMutation): TOutput;
+  compileDelete(mutation: DeleteMutation): TOutput;
+}
+```
+
+### Accessing Query AST
+
+Query objects expose their internal state through getter methods:
+
+```typescript
+// SelectQuery
+query.getFields()       // SelectField[] - columns to select
+query.getWhere()        // Condition[] - WHERE conditions
+query.getHaving()       // Condition[] - HAVING conditions
+query.getJoins()        // Join[] - JOIN clauses
+query.getOrderBy()      // OrderClause[] - ORDER BY clauses
+query.getGroupBy()      // ExpressionBase[] - GROUP BY columns
+query.getLimit()        // number | undefined
+query.getOffset()       // number | undefined
+query.getUnionQueries() // { query: SelectQuery, type: UnionType }[]
+query.table             // Table - FROM table
+query.tables            // Table[] - all tables
+
+// Join
+join.getType()          // JoinType - INNER, LEFT, RIGHT, etc.
+join.getTable()         // Table
+join.getCondition()     // Condition | undefined
+
+// Mutations
+mutation.getTable()     // Table
+mutation.getWhere()     // Condition[] (Delete, Update)
+mutation.getValues()    // RowRecord[] (Insert)
+mutation.getSetValues() // RowRecord (Update)
+```
+
+### Condition Types
+
+Use `instanceof` to handle different condition types:
+
+```typescript
+import {
+  BinaryCondition,      // col = val, col > val, etc.
+  LogicalCondition,     // AND, OR
+  BetweenCondition,     // BETWEEN
+  InCondition,          // IN (...)
+  NotInCondition,       // NOT IN (...)
+  NullCondition,        // IS NULL, IS NOT NULL
+  LikeCondition,        // LIKE
+  ColumnComparisonCondition, // col1 = col2
+  NotCondition,         // NOT (...)
+} from 'ts-query';
+
+function compileCondition(condition: Condition): string {
+  if (condition instanceof BinaryCondition) {
+    return `${condition.key} ${condition.operator} ${condition.value}`;
+  }
+  if (condition instanceof LogicalCondition) {
+    return condition.conditions
+      .map(c => compileCondition(c))
+      .join(` ${condition.operator} `);
+  }
+  // ... handle other types
+}
+```
+
+---
+
+## Example: REST API Target
+
+Here's an example of implementing a REST API target:
+
+```typescript
+import {
+  IQueryTarget,
+  SelectQuery,
+  InsertMutation,
+  UpdateMutation,
+  DeleteMutation,
+  Condition,
+  BinaryCondition,
+  LogicalCondition,
+} from 'ts-query';
+
+interface HTTPRequest {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  url: string;
+  params?: Record<string, string>;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+interface RESTTargetOptions {
+  baseUrl: string;
+  /** Map table names to API endpoints */
+  endpoints?: Record<string, string>;
+}
+
+export class RESTTarget implements IQueryTarget<HTTPRequest> {
+  constructor(private options: RESTTargetOptions) {}
+
+  compileSelect(query: SelectQuery): HTTPRequest {
+    const table = query.table?.getTableName() ?? '';
+    const endpoint = this.options.endpoints?.[table] ?? table;
+
+    const params: Record<string, string> = {};
+
+    // Handle field selection
+    const fields = query.getFields();
+    if (fields.length > 0) {
+      params.fields = fields
+        .map(f => this.extractColumnName(f.name))
+        .join(',');
+    }
+
+    // Handle WHERE conditions as query params
+    const where = query.getWhere();
+    if (where.length > 0) {
+      params.filter = this.serializeConditions(where);
+    }
+
+    // Handle pagination
+    const limit = query.getLimit();
+    const offset = query.getOffset();
+    if (limit !== undefined) params.limit = String(limit);
+    if (offset !== undefined) params.offset = String(offset);
+
+    // Handle sorting
+    const orderBy = query.getOrderBy();
+    if (orderBy.length > 0) {
+      params.sort = orderBy
+        .map(o => `${this.extractColumnName(o.field)}:${o.direction.toLowerCase()}`)
+        .join(',');
+    }
+
+    return {
+      method: 'GET',
+      url: `${this.options.baseUrl}/${endpoint}`,
+      params,
+    };
+  }
+
+  compileInsert(mutation: InsertMutation): HTTPRequest {
+    const table = mutation.getTable().getTableName() ?? '';
+    const endpoint = this.options.endpoints?.[table] ?? table;
+    const values = mutation.getValues();
+
+    if (!values || values.length === 0) {
+      throw new Error('INSERT requires values');
+    }
+
+    return {
+      method: 'POST',
+      url: `${this.options.baseUrl}/${endpoint}`,
+      body: values.length === 1
+        ? this.extractRowValues(values[0])
+        : values.map(v => this.extractRowValues(v)),
+      headers: { 'Content-Type': 'application/json' },
+    };
+  }
+
+  compileUpdate(mutation: UpdateMutation): HTTPRequest {
+    const table = mutation.getTable().getTableName() ?? '';
+    const endpoint = this.options.endpoints?.[table] ?? table;
+    const setValues = mutation.getSetValues();
+    const where = mutation.getWhere();
+
+    // Extract ID from WHERE clause for RESTful URL
+    const id = this.extractIdFromConditions(where);
+
+    return {
+      method: 'PATCH',
+      url: id
+        ? `${this.options.baseUrl}/${endpoint}/${id}`
+        : `${this.options.baseUrl}/${endpoint}`,
+      body: this.extractRowValues(setValues),
+      headers: { 'Content-Type': 'application/json' },
+    };
+  }
+
+  compileDelete(mutation: DeleteMutation): HTTPRequest {
+    const table = mutation.getTable().getTableName() ?? '';
+    const endpoint = this.options.endpoints?.[table] ?? table;
+    const where = mutation.getWhere();
+
+    // Extract ID from WHERE clause for RESTful URL
+    const id = this.extractIdFromConditions(where);
+
+    if (!id) {
+      throw new Error('DELETE requires an id in WHERE clause');
+    }
+
+    return {
+      method: 'DELETE',
+      url: `${this.options.baseUrl}/${endpoint}/${id}`,
+    };
+  }
+
+  private serializeConditions(conditions: Condition[]): string {
+    return conditions
+      .map(c => this.serializeCondition(c))
+      .join(' AND ');
+  }
+
+  private serializeCondition(condition: Condition): string {
+    if (condition instanceof BinaryCondition) {
+      const key = this.extractColumnName(condition.key);
+      const value = this.extractValue(condition.value);
+      return `${key}${condition.operator}${value}`;
+    }
+    if (condition instanceof LogicalCondition) {
+      const parts = condition.conditions.map(c => this.serializeCondition(c));
+      return `(${parts.join(` ${condition.operator} `)})`;
+    }
+    // Handle other condition types...
+    return '';
+  }
+
+  private extractIdFromConditions(conditions: Condition[]): string | undefined {
+    for (const condition of conditions) {
+      if (condition instanceof BinaryCondition && condition.operator === '=') {
+        const key = this.extractColumnName(condition.key);
+        if (key === 'id' || key === '_id') {
+          return String(this.extractValue(condition.value));
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private extractColumnName(expr: any): string {
+    if (typeof expr === 'string') return expr;
+    if (expr?.serialize) {
+      const serialized = expr.serialize();
+      if (!serialized.startsWith('!')) return serialized;
+    }
+    return String(expr);
+  }
+
+  private extractValue(expr: any): any {
+    if (expr?.serialize) {
+      const serialized = expr.serialize();
+      if (serialized.startsWith('!!!')) {
+        return JSON.parse(serialized.substring(3));
+      }
+    }
+    return expr;
+  }
+
+  private extractRowValues(row: Record<string, any>): Record<string, any> {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(row)) {
+      result[key] = this.extractValue(value);
+    }
+    return result;
+  }
+}
+```
+
+### Usage
+
+```typescript
+const target = new RESTTarget({
+  baseUrl: 'https://api.example.com',
+  endpoints: {
+    users: 'v1/users',
+    orders: 'v1/orders',
+  },
+});
+
+// GET request
+const query = Q.select()
+  .from('users')
+  .addField('id')
+  .addField('name')
+  .where(Cond.equal('status', 'active'))
+  .limit(10);
+
+const request = query.compile(target);
+// {
+//   method: 'GET',
+//   url: 'https://api.example.com/v1/users',
+//   params: {
+//     fields: 'id,name',
+//     filter: 'status=active',
+//     limit: '10'
+//   }
+// }
+
+// POST request
+const insert = Q.insert('users').values([{ name: 'John', email: 'john@example.com' }]);
+const postRequest = insert.compile(target);
+// {
+//   method: 'POST',
+//   url: 'https://api.example.com/v1/users',
+//   body: { name: 'John', email: 'john@example.com' },
+//   headers: { 'Content-Type': 'application/json' }
+// }
+
+// PATCH request
+const update = Q.update('users')
+  .set({ name: 'John Doe' })
+  .where(Cond.equal('id', 123));
+const patchRequest = update.compile(target);
+// {
+//   method: 'PATCH',
+//   url: 'https://api.example.com/v1/users/123',
+//   body: { name: 'John Doe' },
+//   headers: { 'Content-Type': 'application/json' }
+// }
+
+// DELETE request
+const del = Q.delete('users').where(Cond.equal('id', 123));
+const deleteRequest = del.compile(target);
+// {
+//   method: 'DELETE',
+//   url: 'https://api.example.com/v1/users/123'
+// }
+```
+
+---
+
+## Handling Unsupported Features
+
+Targets should validate queries and throw clear errors for unsupported features:
+
+```typescript
+private validateSelect(query: SelectQuery): void {
+  if (query.getJoins().length > 0) {
+    throw new Error('This target does not support JOIN operations');
+  }
+  if (query.getGroupBy().length > 0) {
+    throw new Error('This target does not support GROUP BY');
+  }
+  // ... etc
+}
+```
+
+## Capability Detection
+
+Consider adding a static `capabilities` property to help users understand what's supported:
+
+```typescript
+class MyTarget implements IQueryTarget<MyOutput> {
+  static readonly capabilities = {
+    supportsJoins: false,
+    supportsOffset: true,
+    supportsGroupBy: false,
+    supportsTransactions: true,
+    supportedOperators: ['=', '!=', '>', '<', '>=', '<='],
+  };
+
+  // ... implementation
+}
+```

--- a/src/targets/dynamodb/DynamoDBNativeTarget.test.ts
+++ b/src/targets/dynamodb/DynamoDBNativeTarget.test.ts
@@ -1,0 +1,468 @@
+import { Cond } from "../../Condition";
+import { Query } from "../../Query";
+import { DynamoDBNativeTarget } from "./DynamoDBNativeTarget";
+import {
+  DynamoDBQueryInput,
+  DynamoDBScanInput,
+  DynamoDBPutItemInput,
+  DynamoDBUpdateItemInput,
+  DynamoDBDeleteItemInput,
+  DynamoDBBatchWriteItemInput,
+} from "./types";
+
+describe("DynamoDBNativeTarget", () => {
+  describe("compileSelect - Scan mode (no key config)", () => {
+    const target = new DynamoDBNativeTarget();
+
+    it("should compile basic select as Scan", () => {
+      const query = Query.select().from("Users");
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.TableName).toBe("Users");
+      expect(result.FilterExpression).toBeUndefined();
+      expect(result.ProjectionExpression).toBeUndefined();
+    });
+
+    it("should compile select with fields as ProjectionExpression", () => {
+      const query = Query.select()
+        .from("Users")
+        .addField("id")
+        .addField("name");
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.ProjectionExpression).toBe("#n0, #n1");
+      expect(result.ExpressionAttributeNames).toEqual({
+        "#n0": "id",
+        "#n1": "name",
+      });
+    });
+
+    it("should compile WHERE as FilterExpression", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("status", "active"));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("#n0 = :v0");
+      expect(result.ExpressionAttributeNames).toEqual({
+        "#n0": "status",
+      });
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { S: "active" },
+      });
+    });
+
+    it("should handle multiple WHERE conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("status", "active"))
+        .where(Cond.greaterThan("age", 18));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("#n0 = :v0 AND #n1 > :v1");
+      expect(result.ExpressionAttributeNames).toEqual({
+        "#n0": "status",
+        "#n1": "age",
+      });
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { S: "active" },
+        ":v1": { N: "18" },
+      });
+    });
+
+    it("should handle LIMIT", () => {
+      const query = Query.select().from("Users").limit(10);
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.Limit).toBe(10);
+    });
+
+    it("should handle BETWEEN condition", () => {
+      const query = Query.select()
+        .from("Products")
+        .where(Cond.between("price", [10, 100]));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("#n0 BETWEEN :v0 AND :v1");
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { N: "10" },
+        ":v1": { N: "100" },
+      });
+    });
+
+    it("should handle IN condition", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.in("role", ["admin", "user"]));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("#n0 IN (:v0, :v1)");
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { S: "admin" },
+        ":v1": { S: "user" },
+      });
+    });
+
+    it("should handle NULL check as attribute_not_exists", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.isNull("deletedAt"));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("attribute_not_exists(#n0)");
+    });
+
+    it("should handle NOT NULL as attribute_exists", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.isNotNull("email"));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("attribute_exists(#n0)");
+    });
+
+    it("should handle LIKE prefix as begins_with", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.like("sk", "ORDER#%"));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("begins_with(#n0, :v0)");
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { S: "ORDER#" },
+      });
+    });
+
+    it("should handle LIKE substring as contains", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.like("name", "%john%"));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("contains(#n0, :v0)");
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { S: "john" },
+      });
+    });
+
+    it("should handle AND/OR conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(
+          Cond.or([Cond.equal("status", "active"), Cond.equal("status", "pending")])
+        );
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.FilterExpression).toBe("(#n0 = :v0 OR #n0 = :v1)");
+    });
+  });
+
+  describe("compileSelect - Query mode (with key config)", () => {
+    const target = new DynamoDBNativeTarget({
+      partitionKey: "pk",
+      sortKey: "sk",
+    });
+
+    it("should compile as Query when partition key is in conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"));
+      const result = target.compileSelect(query) as DynamoDBQueryInput;
+
+      expect(result.TableName).toBe("Users");
+      expect(result.KeyConditionExpression).toBe("#n0 = :v0");
+      expect(result.FilterExpression).toBeUndefined();
+    });
+
+    it("should separate key conditions from filter conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .where(Cond.equal("status", "active"));
+      const result = target.compileSelect(query) as DynamoDBQueryInput;
+
+      expect(result.KeyConditionExpression).toBe("#n0 = :v0");
+      expect(result.FilterExpression).toBe("#n1 = :v1");
+    });
+
+    it("should include sort key in KeyConditionExpression", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .where(Cond.like("sk", "ORDER#%"));
+      const result = target.compileSelect(query) as DynamoDBQueryInput;
+
+      expect(result.KeyConditionExpression).toBe(
+        "#n0 = :v0 AND begins_with(#n1, :v1)"
+      );
+    });
+
+    it("should handle ORDER BY as ScanIndexForward", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .orderBy("sk", "DESC");
+      const result = target.compileSelect(query) as DynamoDBQueryInput;
+
+      expect(result.ScanIndexForward).toBe(false);
+    });
+
+    it("should set ScanIndexForward true for ASC", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .orderBy("sk", "ASC");
+      const result = target.compileSelect(query) as DynamoDBQueryInput;
+
+      expect(result.ScanIndexForward).toBe(true);
+    });
+  });
+
+  describe("compileSelect - with index", () => {
+    it("should include IndexName when specified", () => {
+      const target = new DynamoDBNativeTarget({
+        partitionKey: "gsi1pk",
+        sortKey: "gsi1sk",
+        indexName: "GSI1",
+      });
+
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("gsi1pk", "EMAIL#john@example.com"));
+      const result = target.compileSelect(query) as DynamoDBQueryInput;
+
+      expect(result.IndexName).toBe("GSI1");
+    });
+  });
+
+  describe("compileSelect - consistent read", () => {
+    it("should set ConsistentRead when specified", () => {
+      const target = new DynamoDBNativeTarget({ consistentRead: true });
+
+      const query = Query.select().from("Users");
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      expect(result.ConsistentRead).toBe(true);
+    });
+  });
+
+  describe("compileSelect - force scan", () => {
+    it("should use Scan when forceScan is true", () => {
+      const target = new DynamoDBNativeTarget({
+        partitionKey: "pk",
+        forceScan: true,
+      });
+
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"));
+      const result = target.compileSelect(query) as DynamoDBScanInput;
+
+      // Should be a Scan with FilterExpression, not Query with KeyCondition
+      expect(result.FilterExpression).toBe("#n0 = :v0");
+      expect((result as any).KeyConditionExpression).toBeUndefined();
+    });
+  });
+
+  describe("compileInsert", () => {
+    const target = new DynamoDBNativeTarget();
+
+    it("should compile single item as PutItem", () => {
+      const mutation = Query.insert("Users").values([
+        { pk: "USER#123", sk: "PROFILE", name: "John" },
+      ]);
+      const result = target.compileInsert(mutation) as DynamoDBPutItemInput;
+
+      expect(result.TableName).toBe("Users");
+      expect(result.Item).toEqual({
+        pk: { S: "USER#123" },
+        sk: { S: "PROFILE" },
+        name: { S: "John" },
+      });
+    });
+
+    it("should handle different value types", () => {
+      const mutation = Query.insert("Products").values([
+        {
+          id: "prod1",
+          price: 99.99,
+          inStock: true,
+          tags: ["electronics", "sale"],
+        },
+      ]);
+      const result = target.compileInsert(mutation) as DynamoDBPutItemInput;
+
+      expect(result.Item).toEqual({
+        id: { S: "prod1" },
+        price: { N: "99.99" },
+        inStock: { BOOL: true },
+        tags: { SS: ["electronics", "sale"] },
+      });
+    });
+
+    it("should compile multiple items as BatchWriteItem", () => {
+      const mutation = Query.insert("Users").values([
+        { pk: "USER#1", sk: "PROFILE", name: "John" },
+        { pk: "USER#2", sk: "PROFILE", name: "Jane" },
+      ]);
+      const result = target.compileInsert(
+        mutation
+      ) as DynamoDBBatchWriteItemInput;
+
+      expect(result.RequestItems).toBeDefined();
+      expect(result.RequestItems.Users).toHaveLength(2);
+      expect(result.RequestItems.Users[0].PutRequest?.Item).toEqual({
+        pk: { S: "USER#1" },
+        sk: { S: "PROFILE" },
+        name: { S: "John" },
+      });
+    });
+  });
+
+  describe("compileUpdate", () => {
+    const target = new DynamoDBNativeTarget({
+      partitionKey: "pk",
+      sortKey: "sk",
+    });
+
+    it("should compile update with key and values", () => {
+      const mutation = Query.update("Users")
+        .set({ name: "John Doe", age: 30 })
+        .where(Cond.equal("pk", "USER#123"))
+        .where(Cond.equal("sk", "PROFILE"));
+      const result = target.compileUpdate(mutation) as DynamoDBUpdateItemInput;
+
+      expect(result.TableName).toBe("Users");
+      expect(result.Key).toEqual({
+        pk: { S: "USER#123" },
+        sk: { S: "PROFILE" },
+      });
+      expect(result.UpdateExpression).toBe("SET #n0 = :v0, #n1 = :v1");
+      expect(result.ExpressionAttributeNames).toEqual({
+        "#n0": "name",
+        "#n1": "age",
+      });
+      expect(result.ExpressionAttributeValues).toEqual({
+        ":v0": { S: "John Doe" },
+        ":v1": { N: "30" },
+      });
+    });
+
+    it("should throw without WHERE clause", () => {
+      const mutation = Query.update("Users").set({ name: "John" });
+      expect(() => target.compileUpdate(mutation)).toThrow(
+        "DynamoDB UPDATE requires a WHERE clause"
+      );
+    });
+  });
+
+  describe("compileDelete", () => {
+    const target = new DynamoDBNativeTarget({
+      partitionKey: "pk",
+      sortKey: "sk",
+    });
+
+    it("should compile delete with key", () => {
+      const mutation = Query.delete("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .where(Cond.equal("sk", "PROFILE"));
+      const result = target.compileDelete(mutation) as DynamoDBDeleteItemInput;
+
+      expect(result.TableName).toBe("Users");
+      expect(result.Key).toEqual({
+        pk: { S: "USER#123" },
+        sk: { S: "PROFILE" },
+      });
+    });
+
+    it("should throw without WHERE clause", () => {
+      const mutation = Query.delete("Users");
+      expect(() => target.compileDelete(mutation)).toThrow(
+        "DynamoDB DELETE requires a WHERE clause"
+      );
+    });
+  });
+
+  describe("validation", () => {
+    const target = new DynamoDBNativeTarget();
+
+    it("should throw on JOIN", () => {
+      const query = Query.select()
+        .from("Users")
+        .leftJoin(
+          Query.table("Orders", "o"),
+          Cond.columnEqual("Users.id", "o.userId")
+        );
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support JOIN"
+      );
+    });
+
+    it("should throw on GROUP BY", () => {
+      const query = Query.select().from("Orders").groupBy("userId");
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support GROUP BY"
+      );
+    });
+
+    it("should throw on HAVING", () => {
+      const query = Query.select()
+        .from("Orders")
+        .groupBy("userId")
+        .having(Cond.greaterThan("count", 5));
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support"
+      );
+    });
+
+    it("should throw on OFFSET", () => {
+      const query = Query.select().from("Users").offset(10);
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support OFFSET"
+      );
+    });
+  });
+
+  describe("compile() method integration", () => {
+    const target = new DynamoDBNativeTarget({
+      partitionKey: "pk",
+      sortKey: "sk",
+    });
+
+    it("should work with SelectQuery using target.compileSelect()", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"));
+      const result = target.compileSelect(query);
+      expect(result.TableName).toBe("Users");
+    });
+
+    it("should work with InsertMutation using target.compileInsert()", () => {
+      const mutation = Query.insert("Users").values([
+        { pk: "USER#123", sk: "PROFILE" },
+      ]);
+      const result = target.compileInsert(mutation) as DynamoDBPutItemInput;
+      expect(result.TableName).toBe("Users");
+      expect(result.Item).toBeDefined();
+    });
+
+    it("should work with UpdateMutation using target.compileUpdate()", () => {
+      const mutation = Query.update("Users")
+        .set({ name: "Test" })
+        .where(Cond.equal("pk", "123"))
+        .where(Cond.equal("sk", "PROFILE"));
+      const result = target.compileUpdate(mutation) as DynamoDBUpdateItemInput;
+      expect(result.TableName).toBe("Users");
+      expect(result.UpdateExpression).toBeDefined();
+    });
+
+    it("should work with DeleteMutation using target.compileDelete()", () => {
+      const mutation = Query.delete("Users")
+        .where(Cond.equal("pk", "123"))
+        .where(Cond.equal("sk", "PROFILE"));
+      const result = target.compileDelete(mutation) as DynamoDBDeleteItemInput;
+      expect(result.TableName).toBe("Users");
+      expect(result.Key).toBeDefined();
+    });
+  });
+});

--- a/src/targets/dynamodb/DynamoDBNativeTarget.ts
+++ b/src/targets/dynamodb/DynamoDBNativeTarget.ts
@@ -1,0 +1,713 @@
+import {
+  BetweenCondition,
+  BinaryCondition,
+  ColumnComparisonCondition,
+  Condition,
+  InCondition,
+  LikeCondition,
+  LogicalCondition,
+  NotCondition,
+  NotInCondition,
+  NullCondition,
+} from "../../Condition";
+import { ExpressionBase } from "../../Expression";
+import { IQueryTarget } from "../../interfaces";
+import { DeleteMutation, InsertMutation, UpdateMutation } from "../../Mutation";
+import { SelectQuery } from "../../Query";
+import {
+  AttributeValue,
+  DynamoDBBatchWriteItemInput,
+  DynamoDBDeleteItemInput,
+  DynamoDBInput,
+  DynamoDBPutItemInput,
+  DynamoDBQueryInput,
+  DynamoDBScanInput,
+  DynamoDBUpdateItemInput,
+  ExpressionAttributeNameMap,
+  ExpressionAttributeValueMap,
+} from "./types";
+
+/**
+ * Options for DynamoDB Native Target
+ */
+export interface DynamoDBNativeTargetOptions {
+  /**
+   * Partition key attribute name(s). When specified, conditions on these
+   * attributes will be placed in KeyConditionExpression for Query operations.
+   * Without this, all operations default to Scan.
+   */
+  partitionKey?: string;
+
+  /**
+   * Sort key attribute name. When specified along with partitionKey,
+   * conditions on this attribute will be placed in KeyConditionExpression.
+   */
+  sortKey?: string;
+
+  /**
+   * Index name for GSI or LSI queries
+   */
+  indexName?: string;
+
+  /**
+   * Use consistent reads (default: false)
+   */
+  consistentRead?: boolean;
+
+  /**
+   * Force Scan operation even if key conditions are present
+   */
+  forceScan?: boolean;
+}
+
+/**
+ * Context for building DynamoDB expressions
+ */
+class ExpressionContext {
+  private nameCounter = 0;
+  private valueCounter = 0;
+  private names: ExpressionAttributeNameMap = {};
+  private values: ExpressionAttributeValueMap = {};
+  private nameMap = new Map<string, string>(); // actual name -> placeholder
+  private valueMap = new Map<string, string>(); // JSON value -> placeholder
+
+  addName(name: string): string {
+    // Check if we already have a placeholder for this name
+    if (this.nameMap.has(name)) {
+      return this.nameMap.get(name)!;
+    }
+
+    const placeholder = `#n${this.nameCounter++}`;
+    this.names[placeholder] = name;
+    this.nameMap.set(name, placeholder);
+    return placeholder;
+  }
+
+  addValue(value: any): string {
+    // Serialize for deduplication
+    const key = JSON.stringify(value);
+    if (this.valueMap.has(key)) {
+      return this.valueMap.get(key)!;
+    }
+
+    const placeholder = `:v${this.valueCounter++}`;
+    this.values[placeholder] = this.toAttributeValue(value);
+    this.valueMap.set(key, placeholder);
+    return placeholder;
+  }
+
+  getNames(): ExpressionAttributeNameMap | undefined {
+    return Object.keys(this.names).length > 0 ? this.names : undefined;
+  }
+
+  getValues(): ExpressionAttributeValueMap | undefined {
+    return Object.keys(this.values).length > 0 ? this.values : undefined;
+  }
+
+  private toAttributeValue(value: any): AttributeValue {
+    if (value === null || value === undefined) {
+      return { NULL: true };
+    }
+    if (typeof value === "string") {
+      return { S: value };
+    }
+    if (typeof value === "number") {
+      return { N: String(value) };
+    }
+    if (typeof value === "boolean") {
+      return { BOOL: value };
+    }
+    if (value instanceof Date) {
+      return { S: value.toISOString() };
+    }
+    if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+      return { B: value };
+    }
+    if (Array.isArray(value)) {
+      // Check if it's a string set, number set, or list
+      if (value.length > 0) {
+        if (value.every((v) => typeof v === "string")) {
+          return { SS: value };
+        }
+        if (value.every((v) => typeof v === "number")) {
+          return { NS: value.map(String) };
+        }
+      }
+      return { L: value.map((v) => this.toAttributeValue(v)) };
+    }
+    if (typeof value === "object") {
+      const map: Record<string, AttributeValue> = {};
+      for (const [k, v] of Object.entries(value)) {
+        map[k] = this.toAttributeValue(v);
+      }
+      return { M: map };
+    }
+    return { S: String(value) };
+  }
+}
+
+/**
+ * DynamoDB Native Target
+ *
+ * Compiles ts-query queries to DynamoDB API input objects that can be used
+ * directly with AWS SDK's Query, Scan, PutItem, UpdateItem, DeleteItem, etc.
+ *
+ * @example
+ * ```typescript
+ * const target = new DynamoDBNativeTarget({
+ *   partitionKey: 'pk',
+ *   sortKey: 'sk'
+ * });
+ *
+ * const query = Q.select()
+ *   .from("Users")
+ *   .addField("id")
+ *   .addField("name")
+ *   .where(Cond.equal("pk", "USER#123"))
+ *   .where(Cond.beginsWith("sk", "ORDER#"))
+ *   .limit(10);
+ *
+ * const input = query.compile(target);
+ * // Returns DynamoDBQueryInput with:
+ * // - KeyConditionExpression
+ * // - ProjectionExpression
+ * // - ExpressionAttributeNames
+ * // - ExpressionAttributeValues
+ * ```
+ */
+export class DynamoDBNativeTarget implements IQueryTarget<DynamoDBInput> {
+  constructor(private options: DynamoDBNativeTargetOptions = {}) {}
+
+  compileSelect(query: SelectQuery): DynamoDBQueryInput | DynamoDBScanInput {
+    this.validateSelect(query);
+
+    const ctx = new ExpressionContext();
+    const table = query.table;
+
+    if (!table) {
+      throw new Error("DynamoDB requires a table name");
+    }
+
+    const tableName = table.getTableName();
+    const where = query.getWhere();
+
+    // Separate key conditions from filter conditions
+    const { keyConditions, filterConditions } = this.separateConditions(
+      where,
+      ctx
+    );
+
+    // Determine if we can use Query or must use Scan
+    const canQuery =
+      !this.options.forceScan &&
+      this.options.partitionKey &&
+      keyConditions.length > 0;
+
+    // Build projection expression
+    const fields = query.getFields();
+    let projectionExpression: string | undefined;
+    if (fields.length > 0) {
+      projectionExpression = fields
+        .map((f) => {
+          const fieldName = this.extractColumnName(f.name);
+          return ctx.addName(fieldName);
+        })
+        .join(", ");
+    }
+
+    // Build base input
+    const baseInput = {
+      TableName: tableName,
+      ...(this.options.indexName && { IndexName: this.options.indexName }),
+      ...(projectionExpression && { ProjectionExpression: projectionExpression }),
+      ...(query.getLimit() !== undefined && { Limit: query.getLimit() }),
+      ...(this.options.consistentRead && { ConsistentRead: true }),
+      ExpressionAttributeNames: ctx.getNames(),
+      ExpressionAttributeValues: ctx.getValues(),
+    };
+
+    if (canQuery) {
+      // Build Query input
+      const input: DynamoDBQueryInput = {
+        ...baseInput,
+        KeyConditionExpression: keyConditions.join(" AND "),
+      };
+
+      if (filterConditions.length > 0) {
+        input.FilterExpression = filterConditions.join(" AND ");
+      }
+
+      // Handle ORDER BY for sort key
+      const orderBy = query.getOrderBy();
+      if (orderBy.length > 0) {
+        // DynamoDB only supports ascending/descending on sort key
+        input.ScanIndexForward = orderBy[0].direction === "ASC";
+      }
+
+      return this.cleanInput(input) as DynamoDBQueryInput;
+    } else {
+      // Build Scan input
+      const allConditions = [...keyConditions, ...filterConditions];
+      const input: DynamoDBScanInput = {
+        ...baseInput,
+        ...(allConditions.length > 0 && {
+          FilterExpression: allConditions.join(" AND "),
+        }),
+      };
+
+      return this.cleanInput(input) as DynamoDBScanInput;
+    }
+  }
+
+  compileInsert(
+    mutation: InsertMutation
+  ): DynamoDBPutItemInput | DynamoDBBatchWriteItemInput {
+    const table = mutation.getTable();
+    const tableName = table.getTableName();
+    const values = mutation.getValues();
+
+    if (!values || values.length === 0) {
+      throw new Error("INSERT requires values");
+    }
+
+    if (values.length === 1) {
+      // Single item - use PutItem
+      const item = this.toAttributeValueMap(values[0]);
+      return {
+        TableName: tableName,
+        Item: item,
+      };
+    }
+
+    // Multiple items - use BatchWriteItem
+    const requests = values.map((row) => ({
+      PutRequest: {
+        Item: this.toAttributeValueMap(row),
+      },
+    }));
+
+    return {
+      RequestItems: {
+        [tableName]: requests,
+      },
+    };
+  }
+
+  compileUpdate(mutation: UpdateMutation): DynamoDBUpdateItemInput {
+    const ctx = new ExpressionContext();
+    const table = mutation.getTable();
+    const tableName = table.getTableName();
+    const setValues = mutation.getSetValues();
+    const where = mutation.getWhere();
+
+    if (Object.keys(setValues).length === 0) {
+      throw new Error("UPDATE requires at least one value to set");
+    }
+
+    if (where.length === 0) {
+      throw new Error("DynamoDB UPDATE requires a WHERE clause with the key");
+    }
+
+    // Build SET clause
+    const setExpressions = Object.entries(setValues).map(([key, value]) => {
+      const namePlaceholder = ctx.addName(key);
+      const valuePlaceholder = ctx.addValue(this.extractValue(value));
+      return `${namePlaceholder} = ${valuePlaceholder}`;
+    });
+
+    // Extract key from WHERE conditions
+    const key = this.extractKeyFromConditions(where);
+
+    // Build condition expression from remaining conditions
+    const conditionExpression = where
+      .filter((c) => !this.isKeyCondition(c))
+      .map((c) => this.compileCondition(c, ctx))
+      .join(" AND ");
+
+    const input: DynamoDBUpdateItemInput = {
+      TableName: tableName,
+      Key: key,
+      UpdateExpression: `SET ${setExpressions.join(", ")}`,
+      ExpressionAttributeNames: ctx.getNames(),
+      ExpressionAttributeValues: ctx.getValues(),
+    };
+
+    if (conditionExpression) {
+      input.ConditionExpression = conditionExpression;
+    }
+
+    return this.cleanInput(input) as DynamoDBUpdateItemInput;
+  }
+
+  compileDelete(mutation: DeleteMutation): DynamoDBDeleteItemInput {
+    const ctx = new ExpressionContext();
+    const table = mutation.getTable();
+    const tableName = table.getTableName();
+    const where = mutation.getWhere();
+
+    if (where.length === 0) {
+      throw new Error("DynamoDB DELETE requires a WHERE clause with the key");
+    }
+
+    // Extract key from WHERE conditions
+    const key = this.extractKeyFromConditions(where);
+
+    // Build condition expression from remaining conditions
+    const conditionExpression = where
+      .filter((c) => !this.isKeyCondition(c))
+      .map((c) => this.compileCondition(c, ctx))
+      .join(" AND ");
+
+    const input: DynamoDBDeleteItemInput = {
+      TableName: tableName,
+      Key: key,
+      ExpressionAttributeNames: ctx.getNames(),
+      ExpressionAttributeValues: ctx.getValues(),
+    };
+
+    if (conditionExpression) {
+      input.ConditionExpression = conditionExpression;
+    }
+
+    return this.cleanInput(input) as DynamoDBDeleteItemInput;
+  }
+
+  /**
+   * Validate that the query doesn't use unsupported features
+   */
+  private validateSelect(query: SelectQuery): void {
+    if (query.getJoins().length > 0) {
+      throw new Error("DynamoDB does not support JOIN operations");
+    }
+    if (query.getGroupBy().length > 0) {
+      throw new Error("DynamoDB does not support GROUP BY");
+    }
+    if (query.getHaving().length > 0) {
+      throw new Error("DynamoDB does not support HAVING");
+    }
+    if (query.getUnionQueries().length > 0) {
+      throw new Error("DynamoDB does not support UNION");
+    }
+    if (query.getOffset() !== undefined) {
+      throw new Error(
+        "DynamoDB does not support OFFSET. Use ExclusiveStartKey for pagination."
+      );
+    }
+  }
+
+  /**
+   * Separate conditions into key conditions and filter conditions
+   */
+  private separateConditions(
+    conditions: Condition[],
+    ctx: ExpressionContext
+  ): { keyConditions: string[]; filterConditions: string[] } {
+    const keyConditions: string[] = [];
+    const filterConditions: string[] = [];
+
+    for (const condition of conditions) {
+      const columnName = this.getConditionColumnName(condition);
+      const compiled = this.compileCondition(condition, ctx);
+
+      if (
+        columnName &&
+        (columnName === this.options.partitionKey ||
+          columnName === this.options.sortKey)
+      ) {
+        keyConditions.push(compiled);
+      } else {
+        filterConditions.push(compiled);
+      }
+    }
+
+    return { keyConditions, filterConditions };
+  }
+
+  /**
+   * Get the column name from a condition (if it's a simple condition)
+   */
+  private getConditionColumnName(condition: Condition): string | null {
+    if (condition instanceof BinaryCondition) {
+      return this.extractColumnName(condition.key);
+    }
+    if (condition instanceof BetweenCondition) {
+      return this.extractColumnName(condition.key);
+    }
+    if (condition instanceof InCondition) {
+      return this.extractColumnName(condition.key);
+    }
+    if (condition instanceof NullCondition) {
+      return this.extractColumnName(condition.key);
+    }
+    if (condition instanceof LikeCondition) {
+      return this.extractColumnName(condition.key);
+    }
+    return null;
+  }
+
+  /**
+   * Check if a condition is a key condition (for UpdateItem/DeleteItem)
+   */
+  private isKeyCondition(condition: Condition): boolean {
+    if (!(condition instanceof BinaryCondition)) return false;
+    if (condition.operator !== "=") return false;
+
+    const columnName = this.extractColumnName(condition.key);
+    return (
+      columnName === this.options.partitionKey ||
+      columnName === this.options.sortKey
+    );
+  }
+
+  /**
+   * Extract key from equality conditions
+   */
+  private extractKeyFromConditions(
+    conditions: Condition[]
+  ): Record<string, AttributeValue> {
+    const key: Record<string, AttributeValue> = {};
+
+    for (const condition of conditions) {
+      if (
+        condition instanceof BinaryCondition &&
+        condition.operator === "="
+      ) {
+        const columnName = this.extractColumnName(condition.key);
+        if (
+          columnName === this.options.partitionKey ||
+          columnName === this.options.sortKey
+        ) {
+          key[columnName] = this.toSingleAttributeValue(
+            this.extractValue(condition.value)
+          );
+        }
+      }
+    }
+
+    return key;
+  }
+
+  /**
+   * Compile a condition to DynamoDB expression syntax
+   */
+  private compileCondition(condition: Condition, ctx: ExpressionContext): string {
+    if (condition instanceof BinaryCondition) {
+      const keyName = this.extractColumnName(condition.key);
+      const namePlaceholder = ctx.addName(keyName);
+      const valuePlaceholder = ctx.addValue(this.extractValue(condition.value));
+      return `${namePlaceholder} ${condition.operator} ${valuePlaceholder}`;
+    }
+
+    if (condition instanceof LogicalCondition) {
+      const parts = condition.conditions.map((c) =>
+        this.compileCondition(c, ctx)
+      );
+      return `(${parts.join(` ${condition.operator} `)})`;
+    }
+
+    if (condition instanceof BetweenCondition) {
+      const keyName = this.extractColumnName(condition.key);
+      const namePlaceholder = ctx.addName(keyName);
+      const fromPlaceholder = ctx.addValue(this.extractValue(condition.from));
+      const toPlaceholder = ctx.addValue(this.extractValue(condition.to));
+      return `${namePlaceholder} BETWEEN ${fromPlaceholder} AND ${toPlaceholder}`;
+    }
+
+    if (condition instanceof InCondition) {
+      const keyName = this.extractColumnName(condition.key);
+      const namePlaceholder = ctx.addName(keyName);
+      const valuePlaceholders = condition.values.map((v) =>
+        ctx.addValue(this.extractValue(v))
+      );
+      return `${namePlaceholder} IN (${valuePlaceholders.join(", ")})`;
+    }
+
+    if (condition instanceof NotInCondition) {
+      const keyName = this.extractColumnName(condition.key);
+      const namePlaceholder = ctx.addName(keyName);
+      const valuePlaceholders = condition.values.map((v) =>
+        ctx.addValue(this.extractValue(v))
+      );
+      return `NOT (${namePlaceholder} IN (${valuePlaceholders.join(", ")}))`;
+    }
+
+    if (condition instanceof NullCondition) {
+      const keyName = this.extractColumnName(condition.key);
+      const namePlaceholder = ctx.addName(keyName);
+      return condition.isNull
+        ? `attribute_not_exists(${namePlaceholder})`
+        : `attribute_exists(${namePlaceholder})`;
+    }
+
+    if (condition instanceof LikeCondition) {
+      const keyName = this.extractColumnName(condition.key);
+      const namePlaceholder = ctx.addName(keyName);
+      const pattern = condition.pattern;
+      const notPrefix = condition.isLike ? "" : "NOT ";
+
+      if (pattern.startsWith("%") && pattern.endsWith("%")) {
+        const searchTerm = pattern.slice(1, -1);
+        const valuePlaceholder = ctx.addValue(searchTerm);
+        return `${notPrefix}contains(${namePlaceholder}, ${valuePlaceholder})`;
+      } else if (pattern.endsWith("%")) {
+        const searchTerm = pattern.slice(0, -1);
+        const valuePlaceholder = ctx.addValue(searchTerm);
+        return `${notPrefix}begins_with(${namePlaceholder}, ${valuePlaceholder})`;
+      } else if (pattern.startsWith("%")) {
+        const searchTerm = pattern.slice(1);
+        const valuePlaceholder = ctx.addValue(searchTerm);
+        return `${notPrefix}contains(${namePlaceholder}, ${valuePlaceholder})`;
+      } else {
+        const valuePlaceholder = ctx.addValue(pattern);
+        return `${namePlaceholder} ${condition.isLike ? "=" : "<>"} ${valuePlaceholder}`;
+      }
+    }
+
+    if (condition instanceof ColumnComparisonCondition) {
+      const leftName = this.extractColumnName(condition.leftKey);
+      const rightName = this.extractColumnName(condition.rightKey);
+      const leftPlaceholder = ctx.addName(leftName);
+      const rightPlaceholder = ctx.addName(rightName);
+      return `${leftPlaceholder} ${condition.operator} ${rightPlaceholder}`;
+    }
+
+    if (condition instanceof NotCondition) {
+      return `NOT (${this.compileCondition(condition.condition, ctx)})`;
+    }
+
+    throw new Error(
+      `Unsupported condition type: ${condition.constructor.name}`
+    );
+  }
+
+  /**
+   * Extract column name from an expression
+   * Handles serialized format:
+   * - Column: just the column name string like "id"
+   */
+  private extractColumnName(expr: ExpressionBase | any): string {
+    if (typeof expr === "string") {
+      return expr;
+    }
+
+    if (expr && typeof expr.serialize === "function") {
+      const serialized = expr.serialize();
+      // Column expressions serialize to just the column name
+      // e.g., "id", "pk", "user.name"
+      if (!serialized.startsWith("!") && !serialized.startsWith("{")) {
+        return serialized;
+      }
+    }
+
+    return String(expr);
+  }
+
+  /**
+   * Extract raw value from an expression
+   * Handles serialized formats:
+   * - Value: "!!!" + JSON.stringify(value) like "!!!\"hello\""
+   * - Raw: "!!" + JSON.stringify(value) + "!!" like "!!\"NULL\"!!"
+   * - Date: "!D!" + timestamp + "!!" like "!D!1234567890!!"
+   * - Column: just the column name (pass through)
+   */
+  private extractValue(expr: ExpressionBase | any): any {
+    if (expr && typeof expr.serialize === "function") {
+      const serialized = expr.serialize();
+
+      // Value expression: starts with !!!
+      if (serialized.startsWith("!!!")) {
+        const jsonStr = serialized.substring(3);
+        return JSON.parse(jsonStr);
+      }
+
+      // Date expression: starts with !D!
+      if (serialized.startsWith("!D!")) {
+        const timestamp = parseInt(
+          serialized.substring(3, serialized.length - 2),
+          10
+        );
+        return new Date(timestamp);
+      }
+
+      // Raw expression: starts and ends with !!
+      if (serialized.startsWith("!!") && serialized.endsWith("!!")) {
+        const jsonStr = serialized.substring(2, serialized.length - 2);
+        return JSON.parse(jsonStr);
+      }
+
+      // Plain string (column name or literal)
+      return serialized;
+    }
+
+    return expr;
+  }
+
+  /**
+   * Convert a record to DynamoDB AttributeValue map
+   */
+  private toAttributeValueMap(
+    row: Record<string, any>
+  ): Record<string, AttributeValue> {
+    const result: Record<string, AttributeValue> = {};
+    for (const [key, value] of Object.entries(row)) {
+      result[key] = this.toSingleAttributeValue(this.extractValue(value));
+    }
+    return result;
+  }
+
+  /**
+   * Convert a single value to AttributeValue
+   */
+  private toSingleAttributeValue(value: any): AttributeValue {
+    if (value === null || value === undefined) {
+      return { NULL: true };
+    }
+    if (typeof value === "string") {
+      return { S: value };
+    }
+    if (typeof value === "number") {
+      return { N: String(value) };
+    }
+    if (typeof value === "boolean") {
+      return { BOOL: value };
+    }
+    if (value instanceof Date) {
+      return { S: value.toISOString() };
+    }
+    if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+      return { B: value };
+    }
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        if (value.every((v) => typeof v === "string")) {
+          return { SS: value };
+        }
+        if (value.every((v) => typeof v === "number")) {
+          return { NS: value.map(String) };
+        }
+      }
+      return { L: value.map((v) => this.toSingleAttributeValue(v)) };
+    }
+    if (typeof value === "object") {
+      const map: Record<string, AttributeValue> = {};
+      for (const [k, v] of Object.entries(value)) {
+        map[k] = this.toSingleAttributeValue(v);
+      }
+      return { M: map };
+    }
+    return { S: String(value) };
+  }
+
+  /**
+   * Remove undefined values from input object
+   */
+  private cleanInput<T extends object>(input: T): T {
+    const result: any = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (value !== undefined) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+}

--- a/src/targets/dynamodb/DynamoDBPartiQLTarget.test.ts
+++ b/src/targets/dynamodb/DynamoDBPartiQLTarget.test.ts
@@ -1,0 +1,307 @@
+import { Cond } from "../../Condition";
+import { Fn } from "../../Function";
+import { Query } from "../../Query";
+import { DynamoDBPartiQLTarget } from "./DynamoDBPartiQLTarget";
+
+describe("DynamoDBPartiQLTarget", () => {
+  const target = new DynamoDBPartiQLTarget();
+
+  describe("compileSelect", () => {
+    it("should compile basic select query", () => {
+      const query = Query.select().from("Users");
+      expect(target.compileSelect(query)).toBe("SELECT * FROM Users");
+    });
+
+    it("should compile select with specific fields", () => {
+      const query = Query.select()
+        .from("Users")
+        .addField("id")
+        .addField("name")
+        .addField("email");
+      expect(target.compileSelect(query)).toBe(
+        "SELECT id, name, email FROM Users"
+      );
+    });
+
+    it("should compile select with table alias", () => {
+      const query = Query.select().from("Users", "u");
+      expect(target.compileSelect(query)).toBe("SELECT * FROM Users AS u");
+    });
+
+    it("should compile select with WHERE conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("id", "user123"));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE id = 'user123'"
+      );
+    });
+
+    it("should compile select with multiple WHERE conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .where(Cond.greaterThan("age", 18));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE pk = 'USER#123' AND age > 18"
+      );
+    });
+
+    it("should compile select with AND/OR conditions", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(
+          Cond.and([
+            Cond.equal("status", "active"),
+            Cond.or([Cond.equal("role", "admin"), Cond.equal("role", "user")]),
+          ])
+        );
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE (status = 'active' AND (role = 'admin' OR role = 'user'))"
+      );
+    });
+
+    it("should compile select with BETWEEN condition", () => {
+      const query = Query.select()
+        .from("Orders")
+        .where(Cond.between("total", [100, 500]));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Orders WHERE total BETWEEN 100 AND 500"
+      );
+    });
+
+    it("should compile select with IN condition", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.in("status", ["active", "pending"]));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE status IN ('active', 'pending')"
+      );
+    });
+
+    it("should compile NULL check as IS MISSING", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.isNull("deletedAt"));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE deletedAt IS MISSING"
+      );
+    });
+
+    it("should compile NOT NULL check as IS NOT MISSING", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.isNotNull("email"));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE email IS NOT MISSING"
+      );
+    });
+
+    it("should compile LIKE 'prefix%' as begins_with", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.like("sk", "ORDER#%"));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE begins_with(sk, 'ORDER#')"
+      );
+    });
+
+    it("should compile LIKE '%substring%' as contains", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.like("name", "%john%"));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE contains(name, 'john')"
+      );
+    });
+
+    it("should compile select with LIMIT", () => {
+      const query = Query.select().from("Users").limit(10);
+      expect(target.compileSelect(query)).toBe("SELECT * FROM Users LIMIT 10");
+    });
+
+    it("should compile select with ORDER BY", () => {
+      const query = Query.select()
+        .from("Users")
+        .orderBy("createdAt", "DESC");
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users ORDER BY createdAt DESC"
+      );
+    });
+
+    it("should handle numeric values", () => {
+      const query = Query.select()
+        .from("Products")
+        .where(Cond.equal("price", 99.99));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Products WHERE price = 99.99"
+      );
+    });
+
+    it("should handle boolean values", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("isActive", true));
+      expect(target.compileSelect(query)).toBe(
+        "SELECT * FROM Users WHERE isActive = TRUE"
+      );
+    });
+
+    it("should throw on JOIN", () => {
+      const query = Query.select()
+        .from("Users")
+        .leftJoin(Query.table("Orders", "o"), Cond.columnEqual("Users.id", "o.userId"));
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support JOIN operations"
+      );
+    });
+
+    it("should throw on GROUP BY", () => {
+      const query = Query.select().from("Orders").groupBy("userId");
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support GROUP BY"
+      );
+    });
+
+    it("should throw on OFFSET", () => {
+      const query = Query.select().from("Users").offset(10);
+      expect(() => target.compileSelect(query)).toThrow(
+        "DynamoDB does not support OFFSET"
+      );
+    });
+
+    it("should throw on UNION", () => {
+      const query1 = Query.select().from("Users");
+      const query2 = Query.select().from("Admins");
+      const unionQuery = query1.union(query2);
+      expect(() => target.compileSelect(unionQuery)).toThrow(
+        "DynamoDB does not support UNION"
+      );
+    });
+  });
+
+  describe("compileInsert", () => {
+    it("should compile single item insert", () => {
+      const mutation = Query.insert("Users").values([
+        { id: "user123", name: "John", email: "john@example.com" },
+      ]);
+      expect(target.compileInsert(mutation)).toBe(
+        "INSERT INTO Users VALUE {'id': 'user123', 'name': 'John', 'email': 'john@example.com'}"
+      );
+    });
+
+    it("should compile multiple item insert as multiple statements", () => {
+      const mutation = Query.insert("Users").values([
+        { id: "user1", name: "John" },
+        { id: "user2", name: "Jane" },
+      ]);
+      expect(target.compileInsert(mutation)).toBe(
+        "INSERT INTO Users VALUE {'id': 'user1', 'name': 'John'};\n" +
+          "INSERT INTO Users VALUE {'id': 'user2', 'name': 'Jane'}"
+      );
+    });
+
+    it("should handle numeric and boolean values", () => {
+      const mutation = Query.insert("Products").values([
+        { id: "prod1", price: 99.99, inStock: true },
+      ]);
+      expect(target.compileInsert(mutation)).toBe(
+        "INSERT INTO Products VALUE {'id': 'prod1', 'price': 99.99, 'inStock': TRUE}"
+      );
+    });
+
+    it("should throw on INSERT ... SELECT", () => {
+      const selectQuery = Query.select().from("TempUsers");
+      const mutation = Query.insert("Users").select(selectQuery);
+      expect(() => target.compileInsert(mutation)).toThrow(
+        "DynamoDB PartiQL does not support INSERT ... SELECT"
+      );
+    });
+  });
+
+  describe("compileUpdate", () => {
+    it("should compile update with single value", () => {
+      const mutation = Query.update("Users")
+        .set({ name: "John Doe" })
+        .where(Cond.equal("id", "user123"));
+      expect(target.compileUpdate(mutation)).toBe(
+        "UPDATE Users SET name = 'John Doe' WHERE id = 'user123'"
+      );
+    });
+
+    it("should compile update with multiple values", () => {
+      const mutation = Query.update("Users")
+        .set({ name: "John Doe", status: "active" })
+        .where(Cond.equal("id", "user123"));
+      expect(target.compileUpdate(mutation)).toBe(
+        "UPDATE Users SET name = 'John Doe', status = 'active' WHERE id = 'user123'"
+      );
+    });
+
+    it("should throw without WHERE clause", () => {
+      const mutation = Query.update("Users").set({ name: "John" });
+      expect(() => target.compileUpdate(mutation)).toThrow(
+        "DynamoDB UPDATE requires a WHERE clause"
+      );
+    });
+  });
+
+  describe("compileDelete", () => {
+    it("should compile delete with WHERE condition", () => {
+      const mutation = Query.delete("Users").where(Cond.equal("id", "user123"));
+      expect(target.compileDelete(mutation)).toBe(
+        "DELETE FROM Users WHERE id = 'user123'"
+      );
+    });
+
+    it("should compile delete with multiple conditions", () => {
+      const mutation = Query.delete("Users")
+        .where(Cond.equal("pk", "USER#123"))
+        .where(Cond.equal("sk", "PROFILE"));
+      expect(target.compileDelete(mutation)).toBe(
+        "DELETE FROM Users WHERE pk = 'USER#123' AND sk = 'PROFILE'"
+      );
+    });
+
+    it("should throw without WHERE clause", () => {
+      const mutation = Query.delete("Users");
+      expect(() => target.compileDelete(mutation)).toThrow(
+        "DynamoDB DELETE requires a WHERE clause"
+      );
+    });
+  });
+
+  describe("compile() method integration", () => {
+    it("should work with SelectQuery.compile()", () => {
+      const query = Query.select()
+        .from("Users")
+        .where(Cond.equal("id", "123"));
+      expect(query.compile(target)).toBe(
+        "SELECT * FROM Users WHERE id = '123'"
+      );
+    });
+
+    it("should work with InsertMutation.compile()", () => {
+      const mutation = Query.insert("Users").values([{ id: "123", name: "Test" }]);
+      expect(mutation.compile(target)).toBe(
+        "INSERT INTO Users VALUE {'id': '123', 'name': 'Test'}"
+      );
+    });
+
+    it("should work with UpdateMutation.compile()", () => {
+      const mutation = Query.update("Users")
+        .set({ name: "Test" })
+        .where(Cond.equal("id", "123"));
+      expect(mutation.compile(target)).toBe(
+        "UPDATE Users SET name = 'Test' WHERE id = '123'"
+      );
+    });
+
+    it("should work with DeleteMutation.compile()", () => {
+      const mutation = Query.delete("Users").where(Cond.equal("id", "123"));
+      expect(mutation.compile(target)).toBe(
+        "DELETE FROM Users WHERE id = '123'"
+      );
+    });
+  });
+});

--- a/src/targets/dynamodb/DynamoDBPartiQLTarget.ts
+++ b/src/targets/dynamodb/DynamoDBPartiQLTarget.ts
@@ -1,0 +1,482 @@
+import {
+  BetweenCondition,
+  BinaryCondition,
+  ColumnComparisonCondition,
+  Condition,
+  InCondition,
+  LikeCondition,
+  LogicalCondition,
+  NotCondition,
+  NotInCondition,
+  NullCondition,
+} from "../../Condition";
+import { ExpressionBase } from "../../Expression";
+import { IQueryTarget } from "../../interfaces";
+import { DeleteMutation, InsertMutation, UpdateMutation } from "../../Mutation";
+import { SelectQuery } from "../../Query";
+
+/**
+ * DynamoDB PartiQL Target
+ *
+ * Compiles ts-query queries to PartiQL statements that can be executed
+ * against DynamoDB using the ExecuteStatement API.
+ *
+ * PartiQL is an SQL-compatible query language supported by DynamoDB.
+ * See: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html
+ *
+ * Limitations:
+ * - No JOIN support (DynamoDB doesn't support joins)
+ * - No GROUP BY / HAVING support
+ * - ORDER BY only works on sort key within a partition
+ * - OFFSET is not supported (use ExclusiveStartKey for pagination)
+ * - LIKE patterns are limited
+ *
+ * @example
+ * ```typescript
+ * const target = new DynamoDBPartiQLTarget();
+ * const query = Q.select().from("Users").where(Cond.equal("id", "123"));
+ * const partiql = query.compile(target);
+ * // Returns: "SELECT * FROM Users WHERE id = '123'"
+ * ```
+ */
+export class DynamoDBPartiQLTarget implements IQueryTarget<string> {
+  compileSelect(query: SelectQuery): string {
+    this.validateSelect(query);
+
+    // Build SELECT clause
+    const fields = query.getFields();
+    const columns =
+      fields.length > 0
+        ? fields
+            .map((f) => {
+              const fieldName = this.compileExpression(f.name);
+              return f.alias ? `${fieldName} AS ${f.alias}` : fieldName;
+            })
+            .join(", ")
+        : "*";
+
+    // Build FROM clause
+    const table = query.table;
+    if (!table) {
+      throw new Error("DynamoDB PartiQL requires a table name");
+    }
+    const tableName = table.getTableName();
+    const tableAlias = table.alias ? ` AS ${table.alias}` : "";
+
+    let sql = `SELECT ${columns} FROM ${tableName}${tableAlias}`;
+
+    // Build WHERE clause
+    const where = query.getWhere();
+    if (where.length > 0) {
+      const whereClause = where
+        .map((c) => this.compileCondition(c))
+        .join(" AND ");
+      sql += ` WHERE ${whereClause}`;
+    }
+
+    // Handle ORDER BY (limited in DynamoDB - only works on sort key)
+    const orderBy = query.getOrderBy();
+    if (orderBy.length > 0) {
+      const orderClause = orderBy
+        .map((o) => `${this.compileExpression(o.field)} ${o.direction}`)
+        .join(", ");
+      sql += ` ORDER BY ${orderClause}`;
+    }
+
+    // Handle LIMIT (PartiQL doesn't support OFFSET)
+    const limit = query.getLimit();
+    if (limit !== undefined) {
+      sql += ` LIMIT ${limit}`;
+    }
+
+    return sql;
+  }
+
+  compileInsert(mutation: InsertMutation): string {
+    const table = mutation.getTable();
+    const tableName = table.getTableName();
+    const values = mutation.getValues();
+
+    if (!values || values.length === 0) {
+      const selectWithColumns = mutation.getSelectWithColumns();
+      if (selectWithColumns) {
+        throw new Error(
+          "DynamoDB PartiQL does not support INSERT ... SELECT"
+        );
+      }
+      throw new Error("INSERT requires values");
+    }
+
+    // PartiQL INSERT syntax: INSERT INTO table VALUE {'attr': value, ...}
+    // For multiple items, we return multiple statements
+    if (values.length === 1) {
+      const item = this.compileInsertItem(values[0]);
+      return `INSERT INTO ${tableName} VALUE ${item}`;
+    }
+
+    // Multiple items - return as array of statements (caller can use BatchExecuteStatement)
+    return values
+      .map((row) => {
+        const item = this.compileInsertItem(row);
+        return `INSERT INTO ${tableName} VALUE ${item}`;
+      })
+      .join(";\n");
+  }
+
+  compileUpdate(mutation: UpdateMutation): string {
+    const table = mutation.getTable();
+    const tableName = table.getTableName();
+    const setValues = mutation.getSetValues();
+    const where = mutation.getWhere();
+
+    if (Object.keys(setValues).length === 0) {
+      throw new Error("UPDATE requires at least one value to set");
+    }
+
+    // Build SET clause
+    const setClause = Object.entries(setValues)
+      .map(([key, value]) => `${key} = ${this.compileValue(value)}`)
+      .join(", ");
+
+    let sql = `UPDATE ${tableName} SET ${setClause}`;
+
+    // WHERE clause (required for DynamoDB - must include key)
+    if (where.length === 0) {
+      throw new Error(
+        "DynamoDB UPDATE requires a WHERE clause with the primary key"
+      );
+    }
+    const whereClause = where
+      .map((c) => this.compileCondition(c))
+      .join(" AND ");
+    sql += ` WHERE ${whereClause}`;
+
+    return sql;
+  }
+
+  compileDelete(mutation: DeleteMutation): string {
+    const table = mutation.getTable();
+    const tableName = table.getTableName();
+    const where = mutation.getWhere();
+
+    let sql = `DELETE FROM ${tableName}`;
+
+    // WHERE clause (required for DynamoDB - must include key)
+    if (where.length === 0) {
+      throw new Error(
+        "DynamoDB DELETE requires a WHERE clause with the primary key"
+      );
+    }
+    const whereClause = where
+      .map((c) => this.compileCondition(c))
+      .join(" AND ");
+    sql += ` WHERE ${whereClause}`;
+
+    return sql;
+  }
+
+  /**
+   * Validate that the query doesn't use unsupported features
+   */
+  private validateSelect(query: SelectQuery): void {
+    if (query.getJoins().length > 0) {
+      throw new Error("DynamoDB does not support JOIN operations");
+    }
+    if (query.getGroupBy().length > 0) {
+      throw new Error("DynamoDB does not support GROUP BY");
+    }
+    if (query.getHaving().length > 0) {
+      throw new Error("DynamoDB does not support HAVING");
+    }
+    if (query.getUnionQueries().length > 0) {
+      throw new Error("DynamoDB does not support UNION");
+    }
+    if (query.getOffset() !== undefined) {
+      throw new Error(
+        "DynamoDB does not support OFFSET. Use ExclusiveStartKey for pagination."
+      );
+    }
+  }
+
+  /**
+   * Compile a condition to PartiQL
+   */
+  private compileCondition(condition: Condition): string {
+    if (condition instanceof BinaryCondition) {
+      const key = this.compileExpression(condition.key);
+      const value = this.compileValue(condition.value);
+      return `${key} ${condition.operator} ${value}`;
+    }
+
+    if (condition instanceof LogicalCondition) {
+      const conditions = condition.conditions
+        .map((c) => this.compileCondition(c))
+        .join(` ${condition.operator} `);
+      return `(${conditions})`;
+    }
+
+    if (condition instanceof BetweenCondition) {
+      const key = this.compileExpression(condition.key);
+      const from = this.compileValue(condition.from);
+      const to = this.compileValue(condition.to);
+      return `${key} BETWEEN ${from} AND ${to}`;
+    }
+
+    if (condition instanceof InCondition) {
+      const key = this.compileExpression(condition.key);
+      const values = condition.values
+        .map((v) => this.compileValue(v))
+        .join(", ");
+      return `${key} IN (${values})`;
+    }
+
+    if (condition instanceof NotInCondition) {
+      const key = this.compileExpression(condition.key);
+      const values = condition.values
+        .map((v) => this.compileValue(v))
+        .join(", ");
+      return `NOT (${key} IN (${values}))`;
+    }
+
+    if (condition instanceof NullCondition) {
+      const key = this.compileExpression(condition.key);
+      // PartiQL uses attribute_exists / attribute_not_exists or IS MISSING
+      return condition.isNull
+        ? `${key} IS MISSING`
+        : `${key} IS NOT MISSING`;
+    }
+
+    if (condition instanceof LikeCondition) {
+      const key = this.compileExpression(condition.key);
+      // PartiQL supports contains() for substring matching
+      // LIKE 'foo%' -> begins_with(key, 'foo')
+      // LIKE '%foo%' -> contains(key, 'foo')
+      // LIKE '%foo' -> not directly supported, use contains as approximation
+      const pattern = condition.pattern;
+      const notPrefix = condition.isLike ? "" : "NOT ";
+
+      if (pattern.startsWith("%") && pattern.endsWith("%")) {
+        const searchTerm = pattern.slice(1, -1);
+        return `${notPrefix}contains(${key}, '${this.escapeString(searchTerm)}')`;
+      } else if (pattern.endsWith("%")) {
+        const searchTerm = pattern.slice(0, -1);
+        return `${notPrefix}begins_with(${key}, '${this.escapeString(searchTerm)}')`;
+      } else if (pattern.startsWith("%")) {
+        // No direct support for ends_with, use contains
+        const searchTerm = pattern.slice(1);
+        return `${notPrefix}contains(${key}, '${this.escapeString(searchTerm)}')`;
+      } else {
+        // Exact match
+        return `${key} ${condition.isLike ? "=" : "<>"} '${this.escapeString(pattern)}'`;
+      }
+    }
+
+    if (condition instanceof ColumnComparisonCondition) {
+      const left = this.compileExpression(condition.leftKey);
+      const right = this.compileExpression(condition.rightKey);
+      return `${left} ${condition.operator} ${right}`;
+    }
+
+    if (condition instanceof NotCondition) {
+      return `NOT (${this.compileCondition(condition.condition)})`;
+    }
+
+    throw new Error(`Unsupported condition type: ${condition.constructor.name}`);
+  }
+
+  /**
+   * Compile an expression to PartiQL (typically a column reference)
+   */
+  private compileExpression(expr: ExpressionBase | any): string {
+    if (typeof expr === "string") {
+      // Check if it's a raw SQL expression (contains operators or functions)
+      if (
+        expr.includes("(") ||
+        expr.includes("+") ||
+        expr.includes("-") ||
+        expr.includes("*") ||
+        expr.includes("/")
+      ) {
+        return expr;
+      }
+      // Column name
+      return expr;
+    }
+
+    if (expr && typeof expr.serialize === "function") {
+      const serialized = expr.serialize();
+      return this.parseSerializedExpression(serialized, false);
+    }
+
+    return String(expr);
+  }
+
+  /**
+   * Compile a value for PartiQL (typically a literal value)
+   */
+  private compileValue(value: ExpressionBase | any): string {
+    if (value && typeof value.serialize === "function") {
+      const serialized = value.serialize();
+      return this.parseSerializedExpression(serialized, true);
+    }
+
+    return this.formatValue(value);
+  }
+
+  /**
+   * Parse a serialized expression string
+   * Formats:
+   * - Column: just the column name string like "id"
+   * - Value: "!!!" + JSON.stringify(value) like "!!!\"hello\""
+   * - Raw: "!!" + JSON.stringify(value) + "!!" like "!!\"NULL\"!!"
+   * - Date: "!D!" + timestamp + "!!" like "!D!1234567890!!"
+   * - Function: JSON object with type "function"
+   * - Operation: JSON object with type "operation"
+   */
+  private parseSerializedExpression(serialized: string, asValue: boolean): string {
+    // Value expression: starts with !!!
+    if (serialized.startsWith("!!!")) {
+      const jsonStr = serialized.substring(3);
+      const value = JSON.parse(jsonStr);
+      return this.formatValue(value);
+    }
+
+    // Date expression: starts with !D!
+    if (serialized.startsWith("!D!")) {
+      const timestamp = parseInt(serialized.substring(3, serialized.length - 2), 10);
+      const date = new Date(timestamp);
+      return `'${date.toISOString()}'`;
+    }
+
+    // Raw expression: starts and ends with !!
+    if (serialized.startsWith("!!") && serialized.endsWith("!!")) {
+      const jsonStr = serialized.substring(2, serialized.length - 2);
+      return JSON.parse(jsonStr);
+    }
+
+    // Try to parse as JSON (for function/operation expressions)
+    if (serialized.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(serialized);
+        if (parsed.type === "function") {
+          return this.compileFunction(parsed);
+        }
+        if (parsed.type === "operation") {
+          return this.compileOperation(parsed);
+        }
+      } catch {
+        // Not valid JSON, treat as column name
+      }
+    }
+
+    // Plain string - treat as column name or value
+    if (asValue) {
+      return this.formatValue(serialized);
+    }
+    return serialized;
+  }
+
+  /**
+   * Format a JavaScript value for PartiQL
+   */
+  private formatValue(value: any): string {
+    if (value === null || value === undefined) {
+      return "NULL";
+    }
+    if (typeof value === "string") {
+      return `'${this.escapeString(value)}'`;
+    }
+    if (typeof value === "number") {
+      return String(value);
+    }
+    if (typeof value === "boolean") {
+      return value ? "TRUE" : "FALSE";
+    }
+    if (value instanceof Date) {
+      return `'${value.toISOString()}'`;
+    }
+    if (Array.isArray(value)) {
+      return `[${value.map((v) => this.formatValue(v)).join(", ")}]`;
+    }
+    if (typeof value === "object") {
+      // Map/object - use PartiQL map literal syntax
+      const entries = Object.entries(value)
+        .map(([k, v]) => `'${k}': ${this.formatValue(v)}`)
+        .join(", ");
+      return `{${entries}}`;
+    }
+    return String(value);
+  }
+
+  /**
+   * Escape a string for PartiQL (single quotes)
+   */
+  private escapeString(str: string): string {
+    return str.replace(/'/g, "''");
+  }
+
+  /**
+   * Compile an INSERT item to PartiQL map syntax
+   */
+  private compileInsertItem(row: Record<string, any>): string {
+    const entries = Object.entries(row)
+      .map(([key, value]) => `'${key}': ${this.compileValue(value)}`)
+      .join(", ");
+    return `{${entries}}`;
+  }
+
+  /**
+   * Compile a function expression
+   */
+  private compileFunction(fn: { name: string; value: any[] }): string {
+    const args = fn.value.map((v) => {
+      if (typeof v === "string") {
+        try {
+          const parsed = JSON.parse(v);
+          if (parsed.type === "column") return parsed.value;
+          if (parsed.type === "value") return this.formatValue(parsed.value);
+          return v;
+        } catch {
+          return v;
+        }
+      }
+      return this.formatValue(v);
+    });
+
+    // Map common SQL functions to PartiQL equivalents
+    switch (fn.name.toUpperCase()) {
+      case "COUNT":
+      case "SUM":
+      case "AVG":
+      case "MIN":
+      case "MAX":
+        // These work in PartiQL for aggregate queries
+        return `${fn.name}(${args.join(", ")})`;
+      case "SIZE":
+        return `size(${args[0]})`;
+      case "ATTRIBUTE_EXISTS":
+        return `attribute_exists(${args[0]})`;
+      case "ATTRIBUTE_NOT_EXISTS":
+        return `attribute_not_exists(${args[0]})`;
+      case "BEGINS_WITH":
+        return `begins_with(${args[0]}, ${args[1]})`;
+      case "CONTAINS":
+        return `contains(${args[0]}, ${args[1]})`;
+      default:
+        return `${fn.name}(${args.join(", ")})`;
+    }
+  }
+
+  /**
+   * Compile an operation expression
+   */
+  private compileOperation(op: {
+    operator: string;
+    left: any;
+    right: any;
+  }): string {
+    const left = this.compileExpression(op.left);
+    const right = this.compileExpression(op.right);
+    return `(${left} ${op.operator} ${right})`;
+  }
+}

--- a/src/targets/dynamodb/index.ts
+++ b/src/targets/dynamodb/index.ts
@@ -1,13 +1,11 @@
-// Query targets for compiling queries to different backends
-export { SQLTarget } from "./SQLTarget";
-
 // DynamoDB targets
+export { DynamoDBPartiQLTarget } from "./DynamoDBPartiQLTarget";
 export {
-  DynamoDBPartiQLTarget,
   DynamoDBNativeTarget,
   type DynamoDBNativeTargetOptions,
-} from "./dynamodb";
+} from "./DynamoDBNativeTarget";
 
+// DynamoDB types
 export type {
   AttributeValue,
   ExpressionAttributeNameMap,
@@ -22,4 +20,4 @@ export type {
   DynamoDBReadInput,
   DynamoDBWriteInput,
   DynamoDBInput,
-} from "./dynamodb";
+} from "./types";

--- a/src/targets/dynamodb/types.ts
+++ b/src/targets/dynamodb/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Type definitions for DynamoDB target outputs.
+ * These mirror the AWS SDK types but are self-contained to avoid requiring aws-sdk as a dependency.
+ */
+
+// Attribute value types
+export type AttributeValue =
+  | { S: string }
+  | { N: string }
+  | { B: Buffer | Uint8Array }
+  | { SS: string[] }
+  | { NS: string[] }
+  | { BS: (Buffer | Uint8Array)[] }
+  | { M: Record<string, AttributeValue> }
+  | { L: AttributeValue[] }
+  | { NULL: boolean }
+  | { BOOL: boolean };
+
+// Expression attribute names map (#name -> actual name)
+export type ExpressionAttributeNameMap = Record<string, string>;
+
+// Expression attribute values map (:value -> AttributeValue)
+export type ExpressionAttributeValueMap = Record<string, AttributeValue>;
+
+/**
+ * DynamoDB Query input parameters
+ */
+export interface DynamoDBQueryInput {
+  TableName: string;
+  IndexName?: string;
+  KeyConditionExpression?: string;
+  FilterExpression?: string;
+  ProjectionExpression?: string;
+  ExpressionAttributeNames?: ExpressionAttributeNameMap;
+  ExpressionAttributeValues?: ExpressionAttributeValueMap;
+  Limit?: number;
+  ScanIndexForward?: boolean;
+  ExclusiveStartKey?: Record<string, AttributeValue>;
+  Select?: "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES" | "SPECIFIC_ATTRIBUTES" | "COUNT";
+  ConsistentRead?: boolean;
+}
+
+/**
+ * DynamoDB Scan input parameters
+ */
+export interface DynamoDBScanInput {
+  TableName: string;
+  IndexName?: string;
+  FilterExpression?: string;
+  ProjectionExpression?: string;
+  ExpressionAttributeNames?: ExpressionAttributeNameMap;
+  ExpressionAttributeValues?: ExpressionAttributeValueMap;
+  Limit?: number;
+  ExclusiveStartKey?: Record<string, AttributeValue>;
+  Select?: "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES" | "SPECIFIC_ATTRIBUTES" | "COUNT";
+  ConsistentRead?: boolean;
+  Segment?: number;
+  TotalSegments?: number;
+}
+
+/**
+ * DynamoDB PutItem input parameters
+ */
+export interface DynamoDBPutItemInput {
+  TableName: string;
+  Item: Record<string, AttributeValue>;
+  ConditionExpression?: string;
+  ExpressionAttributeNames?: ExpressionAttributeNameMap;
+  ExpressionAttributeValues?: ExpressionAttributeValueMap;
+  ReturnValues?: "NONE" | "ALL_OLD";
+}
+
+/**
+ * DynamoDB UpdateItem input parameters
+ */
+export interface DynamoDBUpdateItemInput {
+  TableName: string;
+  Key: Record<string, AttributeValue>;
+  UpdateExpression: string;
+  ConditionExpression?: string;
+  ExpressionAttributeNames?: ExpressionAttributeNameMap;
+  ExpressionAttributeValues?: ExpressionAttributeValueMap;
+  ReturnValues?: "NONE" | "ALL_OLD" | "UPDATED_OLD" | "ALL_NEW" | "UPDATED_NEW";
+}
+
+/**
+ * DynamoDB DeleteItem input parameters
+ */
+export interface DynamoDBDeleteItemInput {
+  TableName: string;
+  Key: Record<string, AttributeValue>;
+  ConditionExpression?: string;
+  ExpressionAttributeNames?: ExpressionAttributeNameMap;
+  ExpressionAttributeValues?: ExpressionAttributeValueMap;
+  ReturnValues?: "NONE" | "ALL_OLD";
+}
+
+/**
+ * DynamoDB BatchWriteItem request item
+ */
+export interface DynamoDBBatchWriteRequest {
+  PutRequest?: { Item: Record<string, AttributeValue> };
+  DeleteRequest?: { Key: Record<string, AttributeValue> };
+}
+
+/**
+ * DynamoDB BatchWriteItem input parameters
+ */
+export interface DynamoDBBatchWriteItemInput {
+  RequestItems: Record<string, DynamoDBBatchWriteRequest[]>;
+}
+
+/**
+ * Union type for all DynamoDB read operations
+ */
+export type DynamoDBReadInput = DynamoDBQueryInput | DynamoDBScanInput;
+
+/**
+ * Union type for all DynamoDB write operations
+ */
+export type DynamoDBWriteInput =
+  | DynamoDBPutItemInput
+  | DynamoDBUpdateItemInput
+  | DynamoDBDeleteItemInput
+  | DynamoDBBatchWriteItemInput;
+
+/**
+ * Union type for all DynamoDB operations (used as target output)
+ */
+export type DynamoDBInput =
+  | DynamoDBQueryInput
+  | DynamoDBScanInput
+  | DynamoDBPutItemInput
+  | DynamoDBUpdateItemInput
+  | DynamoDBDeleteItemInput
+  | DynamoDBBatchWriteItemInput;


### PR DESCRIPTION
## Summary
- Reopen of #11 (accidentally merged and reverted)
- Adds DynamoDB targets (Native + PartiQL) and documents REST API target pattern
- Introduces `IQueryTarget` interface for multi-datasource support