### PR TITLE
DEV-2822: add ifNotExists support to CreateTableAsSelect

### DIFF
--- a/src/CreateTableAsSelect.test.ts
+++ b/src/CreateTableAsSelect.test.ts
@@ -1,4 +1,5 @@
 import { Cond } from "./Condition";
+import { CreateTableAsSelect } from "./CreateTableAsSelect";
 import { Q } from "./Query";
 import { MySQLFlavor } from "./flavors/mysql";
 import { MetadataOperationType } from "./interfaces";
@@ -143,6 +144,56 @@ describe("CreateTableAsSelect", () => {
       expect(deserialized.toSQL(new MySQLFlavor())).toBe(
         ctas.toSQL(new MySQLFlavor())
       );
+    });
+  });
+
+  describe("IF NOT EXISTS", () => {
+    it("should generate CREATE TABLE IF NOT EXISTS SQL", () => {
+      const ctas = Q.createTableIfNotExistsAs(tableName, initialSelectQuery);
+      const expectedSQL = `CREATE TABLE IF NOT EXISTS \`${tableName}\` AS SELECT * FROM \`users\` AS \`u\` WHERE \`u\`.\`id\` = 1`;
+      expect(ctas.toSQL(new MySQLFlavor())).toBe(expectedSQL);
+    });
+
+    it("should clone and preserve ifNotExists flag", () => {
+      const ctas = Q.createTableIfNotExistsAs(tableName, initialSelectQuery);
+      const clone = ctas.clone();
+      expect(clone.getIfNotExists()).toBe(true);
+      expect(clone.toSQL(new MySQLFlavor())).toBe(ctas.toSQL(new MySQLFlavor()));
+    });
+
+    it("should serialize and deserialize correctly", () => {
+      const ctas = Q.createTableIfNotExistsAs(tableName, initialSelectQuery);
+      const serialized = ctas.serialize();
+      const deserialized = Q.deserialize(serialized);
+      expect(deserialized).toEqual(ctas);
+      expect(deserialized.toSQL(new MySQLFlavor())).toBe(
+        ctas.toSQL(new MySQLFlavor())
+      );
+    });
+
+    it("should include ifNotExists field in JSON serialization", () => {
+      const ctas = Q.createTableIfNotExistsAs(tableName, initialSelectQuery);
+      expect(ctas.toJSON().ifNotExists).toBe(true);
+      const plain = Q.createTableAs(tableName, initialSelectQuery);
+      expect(plain.toJSON().ifNotExists).toBe(false);
+    });
+
+    it("should deserialize legacy JSON without ifNotExists field (backwards compatible)", () => {
+      const ctas = Q.createTableAs(tableName, initialSelectQuery);
+      const json = ctas.toJSON() as any;
+      delete json.ifNotExists;
+      const deserialized = Q.deserialize(JSON.stringify(json));
+      expect((deserialized as any).getIfNotExists()).toBe(false);
+      expect(deserialized.toSQL(new MySQLFlavor())).toBe(
+        ctas.toSQL(new MySQLFlavor())
+      );
+    });
+
+    it("should throw when both orReplace and ifNotExists are set", () => {
+      expect(
+        () =>
+          new CreateTableAsSelect(tableName, initialSelectQuery, true, true)
+      ).toThrow(/mutually exclusive/);
     });
   });
 });

--- a/src/CreateTableAsSelect.ts
+++ b/src/CreateTableAsSelect.ts
@@ -17,14 +17,22 @@ export class CreateTableAsSelect
   constructor(
     private _tableName: string,
     private _select: SelectQuery,
-    private _orReplace: boolean = false
-  ) {}
+    private _orReplace: boolean = false,
+    private _ifNotExists: boolean = false
+  ) {
+    if (this._orReplace && this._ifNotExists) {
+      throw new Error(
+        "CreateTableAsSelect: orReplace and ifNotExists are mutually exclusive"
+      );
+    }
+  }
 
   public clone(): this {
     return new (this.constructor as any)(
       this._tableName,
       this._select.clone(),
-      this._orReplace
+      this._orReplace,
+      this._ifNotExists
     );
   }
 
@@ -38,7 +46,8 @@ export class CreateTableAsSelect
 
   toSQL(flavor: ISQLFlavor = new MySQLFlavor()): string {
     const orReplaceStr = this._orReplace ? "OR REPLACE " : "";
-    return `CREATE ${orReplaceStr}TABLE ${flavor.escapeTable(
+    const ifNotExistsStr = this._ifNotExists ? "IF NOT EXISTS " : "";
+    return `CREATE ${orReplaceStr}TABLE ${ifNotExistsStr}${flavor.escapeTable(
       this._tableName
     )} AS ${this._select.toSQL(flavor)}`;
   }
@@ -55,14 +64,21 @@ export class CreateTableAsSelect
       select: this._select.toJSON(),
       tableName: this._tableName,
       orReplace: this._orReplace,
+      ifNotExists: this._ifNotExists,
     };
   }
 
-  static fromJSON({ tableName, select, orReplace }: any): CreateTableAsSelect {
+  static fromJSON({
+    tableName,
+    select,
+    orReplace,
+    ifNotExists,
+  }: any): CreateTableAsSelect {
     return new CreateTableAsSelect(
       tableName,
       SelectQuery.fromJSON(select),
-      orReplace
+      orReplace,
+      ifNotExists
     );
   }
 
@@ -74,5 +90,8 @@ export class CreateTableAsSelect
   }
   getOrReplace(): boolean {
     return this._orReplace;
+  }
+  getIfNotExists(): boolean {
+    return this._ifNotExists;
   }
 }

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -717,6 +717,8 @@ export const Query = {
     new CreateTableAsSelect(table, select),
   createOrReplaceTableAs: (table: string, select: SelectQuery) =>
     new CreateTableAsSelect(table, select, true),
+  createTableIfNotExistsAs: (table: string, select: SelectQuery) =>
+    new CreateTableAsSelect(table, select, false, true),
   createViewAs: (table: string, select: SelectQuery) =>
     new CreateViewAsSelect(table, select),
   createOrReplaceViewAs: (table: string, select: SelectQuery) =>


### PR DESCRIPTION
Idempotentní CTAS varianta pro schema bootstrap na Rekap data platformě (DEV-2838): `createTableAs` selže když tabulka existuje, `createOrReplaceTableAs` je destruktivní — `IF NOT EXISTS` umožní pre-create prázdných Iceberg tabulek (fix first-run ETL blockeru).

## Změny
- Nový flag `_ifNotExists` na `CreateTableAsSelect` + factory `Q.createTableIfNotExistsAs(tableName, select)`
- SQL render: `CREATE TABLE IF NOT EXISTS <tbl> AS <select>` (render centralizovaný, platí pro všechny flavory)
- Serializace: pole `ifNotExists` v `toJSON()`; `fromJSON` zpětně kompatibilní — chybějící pole = `false`
- `orReplace` a `ifNotExists` jsou vzájemně výlučné (konstruktor throwne při obou `true`)
- 6 nových testů (SQL render, clone, serialize/deserialize roundtrip, JSON pole, legacy JSON bez pole, výlučnost)

## Testy
449/449 passed (22 suites), `npm run build` bez chyb.