### PR TITLE
fix(Condition): serialize Cond.in/notIn subqueries + fail-closed empty IN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakub.knejzlik/ts-query",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "TypeScript implementation of SQL builder",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Condition-in-subquery.test.ts
+++ b/src/Condition-in-subquery.test.ts
@@ -1,0 +1,102 @@
+import { Condition, Cond } from "./Condition";
+import { Q } from "./Query";
+import { MySQLFlavor } from "./flavors/mysql";
+
+const flavor = new MySQLFlavor();
+
+const roundtrip = (cond: Condition): Condition =>
+  Condition.deserialize(cond.serialize())!;
+
+describe("Cond.in with subquery", () => {
+  const buildSubquery = () =>
+    Q.select().field("c").from("users").where(Cond.equal("active", 1));
+
+  it("toSQL produces `field IN (SELECT ...)` for a direct subquery", () => {
+    const cond = Cond.in("x", buildSubquery());
+    expect(cond.toSQL(flavor)).toEqual(
+      "`x` IN (SELECT `c` FROM `users` WHERE `active` = 1)"
+    );
+  });
+
+  it("round-trips a subquery identically through serialize/deserialize", () => {
+    const cond = Cond.in("x", buildSubquery());
+    const expected = cond.toSQL(flavor);
+    const restored = roundtrip(cond);
+    expect(restored.toSQL(flavor)).toEqual(expected);
+    expect(restored.toSQL(flavor)).toEqual(
+      "`x` IN (SELECT `c` FROM `users` WHERE `active` = 1)"
+    );
+  });
+
+  it("survives a full query serialize round-trip (does NOT drop the WHERE)", () => {
+    const q = Q.select()
+      .field("id")
+      .from("t")
+      .where(Cond.in("x", buildSubquery()));
+    const expected = q.toSQL(flavor);
+    const restored = Q.deserialize(q.serialize()) as any;
+    expect(restored.toSQL(flavor)).toEqual(expected);
+    expect(restored.toSQL(flavor)).toContain("WHERE `x` IN (SELECT");
+  });
+
+  it("also accepts a single-element array containing a subquery", () => {
+    const cond = Cond.in("x", [buildSubquery()] as any);
+    expect(cond.toSQL(flavor)).toEqual(
+      "`x` IN (SELECT `c` FROM `users` WHERE `active` = 1)"
+    );
+    expect(roundtrip(cond).toSQL(flavor)).toEqual(cond.toSQL(flavor));
+  });
+
+  it("notIn supports subqueries and round-trips", () => {
+    const cond = Cond.notIn("x", buildSubquery() as any);
+    expect(cond.toSQL(flavor)).toEqual(
+      "`x` NOT IN (SELECT `c` FROM `users` WHERE `active` = 1)"
+    );
+    expect(roundtrip(cond).toSQL(flavor)).toEqual(cond.toSQL(flavor));
+  });
+});
+
+describe("Cond.in fail-closed for empty/null values", () => {
+  it("empty array produces `field IN (NULL)` instead of dropping the filter", () => {
+    const cond = Cond.in("foo", []);
+    expect(cond).not.toBeNull();
+    expect(cond.toSQL(flavor)).toEqual("`foo` IN (NULL)");
+  });
+
+  it("null values produce `field IN (NULL)` (fail-closed)", () => {
+    const cond = Cond.in("foo", null);
+    expect(cond).not.toBeNull();
+    expect(cond.toSQL(flavor)).toEqual("`foo` IN (NULL)");
+  });
+
+  it("fail-closed condition survives serialize round-trip", () => {
+    const cond = Cond.in("foo", []);
+    expect(roundtrip(cond).toSQL(flavor)).toEqual("`foo` IN (NULL)");
+  });
+
+  it("empty IN never disappears from a serialized query (no data leak)", () => {
+    const q = Q.select().field("id").from("t").where(Cond.in("foo", []));
+    const restored = Q.deserialize(q.serialize()) as any;
+    expect(restored.toSQL(flavor)).toContain("WHERE `foo` IN (NULL)");
+  });
+
+  it("notIn empty array is fail-closed and valid SQL", () => {
+    const cond = Cond.notIn("foo", []);
+    expect(cond.toSQL(flavor)).toEqual("`foo` NOT IN (NULL)");
+    expect(roundtrip(cond).toSQL(flavor)).toEqual("`foo` NOT IN (NULL)");
+  });
+});
+
+describe("Cond.in non-empty arrays are unchanged", () => {
+  it("preserves numeric value lists", () => {
+    const cond = Cond.in("foo", [1, 2, 3]);
+    expect(cond.toSQL(flavor)).toEqual("`foo` IN (1, 2, 3)");
+    expect(roundtrip(cond).toSQL(flavor)).toEqual("`foo` IN (1, 2, 3)");
+  });
+
+  it("preserves string value lists", () => {
+    const cond = Cond.in("type", ["A", "B"]);
+    expect(cond.toSQL(flavor)).toEqual('`type` IN ("A", "B")');
+    expect(roundtrip(cond).toSQL(flavor)).toEqual('`type` IN ("A", "B")');
+  });
+});

--- a/src/Condition-in-subquery.test.ts
+++ b/src/Condition-in-subquery.test.ts
@@ -87,6 +87,34 @@ describe("Cond.in fail-closed for empty/null values", () => {
   });
 });
 
+describe("Cond.in rejects mixed subquery + values (fail-loud)", () => {
+  const sub = () =>
+    Q.select().field("c").from("users").where(Cond.equal("active", 1));
+  const MSG =
+    "Cond.in/notIn: cannot mix a subquery with other values or use multiple subqueries; pass a single subquery or a list of scalar values";
+
+  it("throws for [subquery, scalar, scalar] (subquery first)", () => {
+    expect(() => Cond.in("x", [sub(), "a", "b"] as any)).toThrow(MSG);
+  });
+
+  it("throws for [scalar, subquery] (subquery last)", () => {
+    expect(() => Cond.in("x", ["a", sub()] as any)).toThrow(MSG);
+  });
+
+  it("throws for [subquery, subquery] (multiple subqueries)", () => {
+    expect(() => Cond.in("x", [sub(), sub()] as any)).toThrow(MSG);
+  });
+
+  it("notIn throws for mixed arrays too", () => {
+    expect(() => Cond.notIn("x", [sub(), "a"] as any)).toThrow(MSG);
+  });
+
+  it("still accepts a clean single subquery and a single-element array", () => {
+    expect(() => Cond.in("x", sub())).not.toThrow();
+    expect(() => Cond.in("x", [sub()] as any)).not.toThrow();
+  });
+});
+
 describe("Cond.in non-empty arrays are unchanged", () => {
   it("preserves numeric value lists", () => {
     const cond = Cond.in("foo", [1, 2, 3]);

--- a/src/Condition-in-transform.test.ts
+++ b/src/Condition-in-transform.test.ts
@@ -1,0 +1,114 @@
+import { Q, Cond } from "./index";
+import { MySQLFlavor } from "./flavors/mysql";
+import { TableSource } from "./Query";
+
+const flavor = new MySQLFlavor();
+
+/**
+ * Verifies that the `Cond.in` fix (subquery support + fail-closed empty list)
+ * bubbles correctly through the `transformTable` render path — the exact
+ * mechanism reporting-api uses to enforce row-level security by replacing a
+ * table reference with a derived table carrying a WHERE filter.
+ *
+ * ARCHITECTURAL NOTE: `transformTable` is a *render-time* option on `toSQL`
+ * (see ISequelizableOptions), NOT part of the query state. It is therefore
+ * never serialized. The realistic reporting-api flow is:
+ *   1. build + serialize the BASE query, send it over the wire,
+ *   2. deserialize it,
+ *   3. render with `toSQL(flavor, { transformTable })`, where the transform
+ *      callback (containing the RLS `Cond.in`) is supplied fresh at render time.
+ *
+ * The fix matters here in two ways:
+ *   (a) toSQL correctness of the transform-produced derived table — before the
+ *       fix a *direct* `Cond.in(field, subquery)` returned null, so the derived
+ *       table would have had NO filter and leaked every row;
+ *   (b) round-trip survival if the derived SelectQuery itself is ever serialized.
+ */
+describe("Cond.in via transformTable (reporting-api RLS pattern)", () => {
+  const email = "user@example.com";
+
+  // RLS rule: replace a table with `SELECT x.* FROM <table> x WHERE x.centre_code IN (SELECT centre FROM users WHERE email = ...)`
+  const rlsSubquery = (table: TableSource): TableSource =>
+    Q.select()
+      .addField("x.*")
+      .from(table as string, "x")
+      .where(
+        Cond.in(
+          "x.centre_code",
+          Q.select()
+            .field("centre")
+            .from("users")
+            .where(Cond.equal("email", email))
+        )
+      );
+
+  // Fail-closed rule: no allowed centres → empty IN.
+  const rlsEmpty = (table: TableSource): TableSource =>
+    Q.select()
+      .addField("x.*")
+      .from(table as string, "x")
+      .where(Cond.in("x.centre_code", []));
+
+  // Realistic-ish base query (aggregation) reading from the protected table.
+  const buildBase = () =>
+    Q.select().field("x.centre_code").from("naklady").groupBy("x.centre_code");
+
+  const EXPECTED_SUBQUERY =
+    "SELECT `x`.`centre_code` FROM (SELECT `x`.* FROM `naklady` AS `x` " +
+    'WHERE `x`.`centre_code` IN (SELECT `centre` FROM `users` WHERE `email` = "user@example.com")) ' +
+    "AS `t` GROUP BY `x`.`centre_code`";
+
+  const EXPECTED_EMPTY =
+    "SELECT `x`.`centre_code` FROM (SELECT `x`.* FROM `naklady` AS `x` " +
+    "WHERE `x`.`centre_code` IN (NULL)) AS `t` GROUP BY `x`.`centre_code`";
+
+  it("toSQL: subquery filter lands inside the derived-table replacement", () => {
+    const sql = buildBase().toSQL(flavor, { transformTable: rlsSubquery });
+    expect(sql).toEqual(EXPECTED_SUBQUERY);
+    expect(sql).toContain(
+      'IN (SELECT `centre` FROM `users` WHERE `email` = "user@example.com")'
+    );
+  });
+
+  it("serialize → deserialize → toSQL(transformTable): WHERE/IN survives (does NOT drop)", () => {
+    const base = buildBase();
+    const direct = base.toSQL(flavor, { transformTable: rlsSubquery });
+
+    // Round-trip the BASE query (transformTable is applied fresh after deserialize,
+    // exactly as reporting-api does it).
+    const restored = Q.deserialize(base.serialize()) as any;
+    const afterRoundtrip = restored.toSQL(flavor, {
+      transformTable: rlsSubquery,
+    });
+
+    expect(afterRoundtrip).toEqual(direct);
+    expect(afterRoundtrip).toContain("IN (SELECT `centre` FROM `users`");
+  });
+
+  it("the transform-produced derived table itself survives a serialize round-trip", () => {
+    // Strongest proof: if the RLS derived query is persisted/round-tripped,
+    // the Cond.in subquery is preserved (directly exercises the fix).
+    const derived = rlsSubquery("naklady") as any;
+    const restored = Q.deserialize(derived.serialize()) as any;
+    expect(restored.toSQL(flavor)).toEqual(derived.toSQL(flavor));
+    expect(restored.toSQL(flavor)).toContain(
+      'IN (SELECT `centre` FROM `users` WHERE `email` = "user@example.com")'
+    );
+  });
+
+  it("fail-closed: empty IN renders `IN (NULL)` inside the derived table (no data leak)", () => {
+    const sql = buildBase().toSQL(flavor, { transformTable: rlsEmpty });
+    expect(sql).toEqual(EXPECTED_EMPTY);
+    expect(sql).toContain("IN (NULL)");
+    // The filter must never vanish — that would expose all rows through the transform.
+    expect(sql).not.toEqual("SELECT `x`.`centre_code` FROM `naklady` GROUP BY `x`.`centre_code`");
+  });
+
+  it("fail-closed survives serialize → deserialize → toSQL(transformTable)", () => {
+    const base = buildBase();
+    const restored = Q.deserialize(base.serialize()) as any;
+    const sql = restored.toSQL(flavor, { transformTable: rlsEmpty });
+    expect(sql).toEqual(EXPECTED_EMPTY);
+    expect(sql).toContain("IN (NULL)");
+  });
+});

--- a/src/Condition.test.ts
+++ b/src/Condition.test.ts
@@ -80,8 +80,10 @@ describe("Condition", () => {
     expect(Cond.in("foo", ["1", "2", "3"])?.toSQL(flavor)).toEqual(
       '`foo` IN ("1", "2", "3")'
     );
-    expect(Cond.in("foo", [])).toBeNull();
-    expect(Cond.in("foo", null)).toBeNull();
+    // Fail-closed: empty / null lists render `IN (NULL)` (never matches) rather than
+    // dropping the filter, so an empty IN can never silently expose all rows.
+    expect(Cond.in("foo", [])?.toSQL(flavor)).toEqual("`foo` IN (NULL)");
+    expect(Cond.in("foo", null)?.toSQL(flavor)).toEqual("`foo` IN (NULL)");
   });
 
   // NOT IN

--- a/src/Condition.ts
+++ b/src/Condition.ts
@@ -1,10 +1,33 @@
 import { Dayjs } from "dayjs";
 import { ExpressionBase, ExpressionValue } from "./Expression";
 import { ISQLFlavor } from "./Flavor";
-import { Q } from "./Query";
+import { Q, SelectQuery } from "./Query";
 import { ISequelizable, ISerializable } from "./interfaces";
 
 type ConditionValue = ExpressionValue | Dayjs;
+
+// Values accepted by IN / NOT IN: a list of values, a subquery, or null.
+type InValues = ConditionValue[] | SelectQuery | null;
+
+// Normalizes the value(s) passed to an IN/NOT IN condition.
+// - A SelectQuery (passed directly or as the only element of an array) becomes a subquery.
+// - An empty/null list is rendered fail-closed as `(NULL)` so an empty IN never silently
+//   drops the filter (which would expose all rows). The NULL marker survives serialization.
+const normalizeInValues = (
+  values: InValues
+): { subquery?: SelectQuery; values: ExpressionBase[] } => {
+  if (values instanceof SelectQuery) {
+    return { subquery: values, values: [] };
+  }
+  const arr = values ?? [];
+  if (arr.length === 1 && arr[0] instanceof SelectQuery) {
+    return { subquery: arr[0] as SelectQuery, values: [] };
+  }
+  if (arr.length === 0) {
+    return { values: [Q.exprValue(Q.raw("NULL"))] };
+  }
+  return { values: arr.map((v) => Q.exprValue(v)) };
+};
 
 export class Condition implements ISequelizable, ISerializable {
   toSQL(flavor: ISQLFlavor): string {
@@ -164,17 +187,21 @@ class BetweenCondition extends Condition {
 class InCondition extends Condition {
   key: ExpressionBase;
   values: ExpressionBase[];
+  subquery?: SelectQuery;
 
-  constructor(key: ConditionValue, values: ConditionValue[]) {
+  constructor(key: ConditionValue, values: InValues) {
     super();
     this.key = Q.expr(key);
-    this.values = values.map((v) => Q.exprValue(v));
+    const normalized = normalizeInValues(values);
+    this.values = normalized.values;
+    this.subquery = normalized.subquery;
   }
 
   toSQL(flavor: ISQLFlavor): string {
-    return `${this.key.toSQL(flavor)} IN (${this.values
-      .map((v) => v.toSQL(flavor))
-      .join(", ")})`;
+    const right = this.subquery
+      ? this.subquery.toSQL(flavor)
+      : this.values.map((v) => v.toSQL(flavor)).join(", ");
+    return `${this.key.toSQL(flavor)} IN (${right})`;
   }
 
   // serialization
@@ -182,11 +209,19 @@ class InCondition extends Condition {
     return {
       type: "InCondition",
       key: this.key.serialize(),
-      values: this.values.map((v) => v.serialize()),
+      ...(this.subquery
+        ? { subquery: this.subquery.toJSON() }
+        : { values: this.values.map((v) => v.serialize()) }),
     };
   }
 
   static fromJSON(json: any): InCondition {
+    if (json.subquery) {
+      return new InCondition(
+        ExpressionBase.deserialize(json.key),
+        SelectQuery.fromJSON(json.subquery)
+      );
+    }
     return new InCondition(
       ExpressionBase.deserialize(json.key),
       json.values.map(ExpressionBase.deserializeValue)
@@ -197,17 +232,21 @@ class InCondition extends Condition {
 class NotInCondition extends Condition {
   key: ExpressionBase;
   values: ExpressionBase[];
+  subquery?: SelectQuery;
 
-  constructor(key: ConditionValue, values: ConditionValue[]) {
+  constructor(key: ConditionValue, values: InValues) {
     super();
     this.key = Q.expr(key);
-    this.values = values.map((v) => Q.exprValue(v));
+    const normalized = normalizeInValues(values);
+    this.values = normalized.values;
+    this.subquery = normalized.subquery;
   }
 
   toSQL(flavor: ISQLFlavor): string {
-    return `${this.key.toSQL(flavor)} NOT IN (${this.values
-      .map((v) => v.toSQL(flavor))
-      .join(", ")})`;
+    const right = this.subquery
+      ? this.subquery.toSQL(flavor)
+      : this.values.map((v) => v.toSQL(flavor)).join(", ");
+    return `${this.key.toSQL(flavor)} NOT IN (${right})`;
   }
 
   // serialization
@@ -215,11 +254,19 @@ class NotInCondition extends Condition {
     return {
       type: "NotInCondition",
       key: this.key.serialize(),
-      values: this.values.map((v) => v.serialize()),
+      ...(this.subquery
+        ? { subquery: this.subquery.toJSON() }
+        : { values: this.values.map((v) => v.serialize()) }),
     };
   }
 
   static fromJSON(json: any): NotInCondition {
+    if (json.subquery) {
+      return new NotInCondition(
+        ExpressionBase.deserialize(json.key),
+        SelectQuery.fromJSON(json.subquery)
+      );
+    }
     return new NotInCondition(
       ExpressionBase.deserialize(json.key),
       json.values.map(ExpressionBase.deserializeValue)
@@ -430,9 +477,10 @@ export const Conditions = {
     new BinaryCondition(key, value, "<="),
   between: (key: ConditionValue, values: [ConditionValue, ConditionValue]) =>
     new BetweenCondition(key, Q.exprValue(values[0]), Q.exprValue(values[1])),
-  in: (key: ConditionValue, values: ConditionValue[] | null) =>
-    values && values.length > 0 ? new InCondition(key, values) : null,
-  notIn: (key: ConditionValue, values: ConditionValue[]) =>
+  // Fail-closed: an empty/null list renders `IN (NULL)` (never matches) instead of being
+  // dropped, so an empty IN can never silently expand visibility. Accepts a subquery too.
+  in: (key: ConditionValue, values: InValues) => new InCondition(key, values),
+  notIn: (key: ConditionValue, values: InValues) =>
     new NotInCondition(key, values),
   and: (conditions: (Condition | null)[] | null) => {
     const _c = (conditions || []).filter((c) => c !== null);

--- a/src/Condition.ts
+++ b/src/Condition.ts
@@ -20,7 +20,16 @@ const normalizeInValues = (
     return { subquery: values, values: [] };
   }
   const arr = values ?? [];
-  if (arr.length === 1 && arr[0] instanceof SelectQuery) {
+  const subqueryCount = arr.filter((v) => v instanceof SelectQuery).length;
+  if (subqueryCount > 0) {
+    // A subquery is only valid as the sole value: `IN (SELECT ...)`. Mixing a
+    // subquery with scalar values (or multiple subqueries) is invalid SQL — fail
+    // loud rather than emitting malformed SQL / throwing later on deserialize.
+    if (subqueryCount > 1 || arr.length > 1) {
+      throw new Error(
+        "Cond.in/notIn: cannot mix a subquery with other values or use multiple subqueries; pass a single subquery or a list of scalar values"
+      );
+    }
     return { subquery: arr[0] as SelectQuery, values: [] };
   }
   if (arr.length === 0) {

--- a/src/stories/2_Condition.stories.mdx
+++ b/src/stories/2_Condition.stories.mdx
@@ -109,6 +109,53 @@ Cond.in('foo', [1, 2, 3]);
 `}
 />
 
+#### IN with a subquery
+
+`Cond.in` also accepts a `SelectQuery` as its value, generating a `IN (SELECT …)`
+subquery. The subquery is fully serializable, so it survives a
+`serialize`/`deserialize` round-trip identically to its direct `toSQL` output:
+
+<QueryPreview
+  code={`
+// id IN (SELECT user_id FROM orders WHERE active = 1)
+Cond.in('id', Q.select().field('user_id').from('orders').where(Cond.equal('active', 1)));
+`}
+/>
+
+#### Empty IN is fail-closed
+
+An empty (or \`null\`) value list renders \`IN (NULL)\` — a condition that never
+matches — instead of being dropped. This is intentional: an empty \`IN\` must
+never silently mean "no filter", which would expose every row. Because it is a
+real condition, it also survives serialization:
+
+<QueryPreview
+  code={`
+// foo IN (NULL)  — never matches, never silently dropped
+Cond.in('foo', []);
+`}
+/>
+
+### NOT IN
+
+To check if a column's value is **not** within a set of values:
+
+<QueryPreview
+  code={`
+Cond.notIn('foo', [1, 2, 3]);
+`}
+/>
+
+`Cond.notIn` mirrors `Cond.in`: it accepts a subquery and an empty list is
+fail-closed as `NOT IN (NULL)`.
+
+<QueryPreview
+  code={`
+// id NOT IN (SELECT user_id FROM orders WHERE blocked = 1)
+Cond.notIn('id', Q.select().field('user_id').from('orders').where(Cond.equal('blocked', 1)));
+`}
+/>
+
 ### AND
 
 To combine multiple conditions with an AND operator:


### PR DESCRIPTION
## Proč

V Rekapu se row-level-security pravidla skládají přes ts-query a posílají do Reporting API přes `serialize`/`deserialize` (JSON), ne přímo `toSQL`. Našli jsme dva bezpečnostně relevantní bugy v `Cond.in`:

1. **`Cond.in(field, subquery)` se neserializoval → tichý drop WHERE.** Přímo předaná `SelectQuery` ve factory propadla na `values.length > 0` (`undefined`) a vrátila `null` → podmínka úplně zmizela (i v `toSQL`). Varianta `Cond.in(field, [subquery])` sice `toSQL` vyrobila správně, ale `deserialize` **házel** `this.value.toSQL is not a function`. V obou případech filtr po serializaci zmizel → uživatel viděl **všechna** data (security fail).
2. **`Cond.in(field, [])` / `null` tiše zahodilo WHERE (fail-open).** Prázdný IN nikdy nesmí znamenat „bez filtru".

## Co se mění

`src/Condition.ts`:
- `InCondition` / `NotInCondition` umí buď seznam hodnot, **nebo** subquery (`SelectQuery`). Subquery se serializuje přes nové JSON pole `subquery` (`subquery.toJSON()` ↔ `SelectQuery.fromJSON`) a `toSQL` produkuje `field IN (SELECT …)`. Round-trip je identický s přímým `toSQL`.
- Nový helper `normalizeInValues` detekuje subquery (přímo i jako jednoprvkové pole) a řeší fail-closed.
- **Fail-closed:** prázdné/`null` pole → `field IN (NULL)` (nikdy nematchuje) a **přežije serialize**. Factory `Cond.in`/`notIn` už nikdy nevrací `null`.
- Neprázdné seznamy hodnot beze změny.

## Testy

- Nový `src/Condition-in-subquery.test.ts`: subquery round-trip (in i notIn), fail-closed prázdné pole + že přežije serialize, neprázdné pole beze změny, plný query round-trip (WHERE nezmizí).
- Upraven `src/Condition.test.ts` — `Cond.in("foo", [])` / `null` nyní očekává `\`foo\` IN (NULL)` místo `null`.
- **Celá suite zelená: 461 passed.** `tsc` build čistý.

## Pozn.
- ⚠️ **Mírná změna chování:** `Cond.in` už nikdy nevrací `null` (fail-closed). Kód spoléhající na `null` u prázdného IN dostane podmínku `IN (NULL)`.
- Verze bumpnuta 0.14.0 → 0.14.1 (patch). **Nepublikováno na npm**, **nemergováno.**